### PR TITLE
Inject user to sqlite db during bootstrap

### DIFF
--- a/kubernetes/sites-pipeline/cronjob.py
+++ b/kubernetes/sites-pipeline/cronjob.py
@@ -395,13 +395,19 @@ def consumeSites():
         docRow = random.choice(resp["rows"])
         # Generate storage
         fsManifest = generateCephFilesystemManifest(docRow["id"])
+        print("#"*45)
+        print(fsManifest)
         # Deploy storage
         deployCephFilesystemManifest(fsManifest)
         # Generate service & deploy
         manifest = generateServiceManifest(docRow["id"])
+        print("#"*45)
+        print(manifest)
         deployServiceManifest(manifest)
         # Generate and deploy deployment
         manifest = generateManifest(docRow["id"])
+        print("#"*45)
+        print(manifest)
         if manifest:
             try:
                 deployManifest(manifest)
@@ -414,6 +420,8 @@ def consumeSites():
         # Generate Ingress & deploy Ingress
         manifest = generateIngressManifest(docRow["id"])
         deployIngressManifest(manifest)
+        print("#"*45)
+        print(manifest)
 
     except IndexError:
         print("Do documents left to process")

--- a/kubernetes/sites-pipeline/cronjob.py
+++ b/kubernetes/sites-pipeline/cronjob.py
@@ -85,7 +85,7 @@ def generateCephFilesystemManifest(docId):
         ],
         "metadataServer": {
           "activeCount": 1,
-          "activeStandby": "true"
+          "activeStandby": True  # True not "true" as operator does not validate
         }
       }
     }

--- a/kubernetes/sites-pipeline/cronjob.py
+++ b/kubernetes/sites-pipeline/cronjob.py
@@ -208,9 +208,14 @@ def generateManifest(docId):
                         "volumes": [
                             {
                                 "name": siteName + "-static",
-                                "persistentVolumeClaim": {
-                                    "claimName": siteName + "-static"
-                                },
+                                "flexVolume": {
+                                  "driver": "ceph.rook.io/rook",
+                                  "fsType": "ceph",
+                                  "options": {
+                                    "fsName": "site-storage-" + siteName,
+                                    "clusterNamespace": "rook-ceph"
+                                  }
+                                }
                             }
                         ],
                     },

--- a/subscribie/bootstrap.py
+++ b/subscribie/bootstrap.py
@@ -141,7 +141,10 @@ def bootstrap(app):
             else:
                 print("NOTICE: {} already present so not overwriting".format(dst))
 
-            # Update jamla path and template folder path
+            # Move database file to persistant volume
+            path = os.path.abspath(__file__ + "../../../")
+            print("Copying data.db from: {}".format(path))
+            shutil.copy(path + "/data.db", "/subscribie/volume/")
             db_full_path = "/subscribie/volume/data.db"
             template_base_dir = "/subscribie/volume/themes/"
             static_folder = "{template_base_dir}theme-{theme_name}/static/".format(
@@ -163,11 +166,6 @@ def bootstrap(app):
             path = os.path.abspath(__file__ + "../../../instance")
             print("Copying config.py from: {}".format(path))
             shutil.copy(path + "/config.py", "/subscribie/volume/")
-
-            # Move database file to persistant volume
-            path = os.path.abspath(__file__ + "../../../")
-            print("Copying data.db from: {}".format(path))
-            shutil.copy(path + "/data.db", "/subscribie/volume/")
 
             # Mark site as bootstrapped
             path = Path("/subscribie/volume/bootstrap_complete")

--- a/subscribie/bootstrap.py
+++ b/subscribie/bootstrap.py
@@ -5,21 +5,26 @@ import yaml
 import subprocess
 import shutil
 from pathlib import Path
+import sqlite3
+import datetime
 
 
 def bootstrap_needed():
-    if (
-        os.getenv("SUBSCRIBIE_FETCH_JAMLA") is not None
-        and os.path.isfile("/subscribie/volume/bootstrap_complete") is False
-    ):
-        print("NOTICE: bootstrap requested")
-        return True
-    else:
-        print(
-            "NOTICE: bootstrap not possible because marked as complete,\
-          or `export SUBSCRIBIE_FETCH_JAMLA=True` not set"
-        )
-        return False
+    print("NOTICE: bootstrap requested")
+    fail = False
+    if os.getenv("SUBSCRIBIE_FETCH_JAMLA") is None:
+      print("SUBSCRIBIE_FETCH_JAMLA is not set")
+      fail = True
+    if os.path.isfile("/subscribie/volume/bootstrap_complete") is True:
+      print("/subscribie/volume/bootstrap_complete already exists")
+      fail = True
+    if fail is True:
+      print(
+          "NOTICE: bootstrap not possible because marked as complete,\
+        or `export SUBSCRIBIE_FETCH_JAMLA=True` not set"
+      )
+      return False
+    return True
 
 
 def bootstrap_possible():

--- a/subscribie/bootstrap.py
+++ b/subscribie/bootstrap.py
@@ -80,22 +80,26 @@ def bootstrap(app):
     """
   Bootstrap a subscribie site whereby the Jamla manifest
   is to be consumed from an external source e.g. a couchdb
-  database. We assume a persistant volume is present at path
-  "/subscribie/volume" this is used to store the Jamla manifest
-  and also mark as bootstrap completed by dropping an empty file
-  'bootstrap_complete' in /subscribie/volume.
-
+  database. We assume a persistant volume is attatched at path
+  "/subscribie/volume" this is used to store:
+    - The Jamla manifest specific to this site
+    - The data.db sqlite3 database for the admin user
+    - To mark site a bootstrap completed by creating an empty file
+      'bootstrap_complete' in /subscribie/volume.
+  The bootstrap works as follows:
     - Work out if we need to bootstrap 
       - By checking for SUBSCRIBIE_FETCH_JAMLA environment var
       - and by checking if exists /subscribie/volume/bootstrap_complete
     - Fetch Jamla manifest from external source (assume couchdb)
-    - Perform bootstrap
+    - Perform bootstrap:
       - Inject Jamla manifest to /subscribie/volume/jamla.yaml
       - Update jamla path in config.py
       - Inject static assets (images, if any, from couchdb attachments) 
-    - Copy config.py to /subscribie/volume/config.py
-    - Mark as bootstrapped
-    - continue running as normal
+      - Copy config.py to /subscribie/volume/config.py
+      - Inject user's email address into data.db (email is in the jamla
+        manifest
+      - Mark as bootstrapped
+      - Continue running as normal
   """
     if bootstrap_needed() and bootstrap_possible():
         print("NOTICE: bootstrapping site")


### PR DESCRIPTION
#27 

-   perform db migrations on data.db and inject initial user. All done on the persistent volume (ceph backed)
-   updated bootstrap.py bootstrap() inline documentation to explain the steps taken during a bootstrap. TODO: convert this to a doc string.
