### PR TITLE
Issue 67 reload app upon shop edit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,4 @@ RUN pip install subscribiecli
 RUN subscribie init
 RUN subscribie migrate
 EXPOSE 8080
-CMD uwsgi --http :8080 --wsgi-file subscribie.wsgi
-
+CMD uwsgi --http :8080 --workders 2 --wsgi-file subscribie.wsgi --touch-chain-reload subscribie.wsgi

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN pip install subscribiecli
 RUN subscribie init
 RUN subscribie migrate
 EXPOSE 8080
-CMD uwsgi --http :8080 --workders 2 --wsgi-file subscribie.wsgi --touch-chain-reload subscribie.wsgi
+CMD uwsgi --http :8080 --workers 2 --wsgi-file subscribie.wsgi --touch-chain-reload subscribie.wsgi


### PR DESCRIPTION
Fix #67 reload app upon shop edit
Trigger a reload by touching the wsgi file.
Which file we need to touch depends on the wsgi config
e.g. on uwsgi to set it to subscribie.wsgi on uwsgi we pass:
uwsgi --http :9090 --workers 2 --wsgi-file subscribie.wsgi --touch-chain-reload subscribie.wsgi
To uwsgi. The `--touch-chain-reload` option tells uwsgi to perform a graceful reload. "When triggered, it will restart one worker at  time, and the following worker is not reloaded until the previous one is ready to accept new requests. We must use more than one worker for this to work. See: https://uwsgi-docs.readthedocs.io/en/latest/articles/TheArtOfGracefulReloading.html#chain-reloading-lazy-apps