### PR TITLE
#162 stripe webhook endpoint & checkout flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ https://subscribie.readthedocs.io
 Provide the username & password in a POST request, and a jwt token is returned for 
 use in further requests. 
 
+# Testing Stripe webhooks locally
+
+1. Install stripe cli https://stripe.com/docs/stripe-cli#install
+2. Run stripe cli
+3. Copy the webhook secret "Ready! Your webhook signing secret is whsec_abc123.."
+3. In your `.env` file set `STRIPE_WEBHOOK_ENDPOINT_SECRET` to the webhook secret
+
+```
+stripe listen --forward-to 127.0.0.1:5000/stripe_webhook
+```
+
+This will allow you to see/process webhook requests locally using test api keys.
+
 # API Basics
 
 ## Oauth style login:

--- a/migrations/versions/5e536de32a31_add_stripe_webhook_endpoint_secret_to_.py
+++ b/migrations/versions/5e536de32a31_add_stripe_webhook_endpoint_secret_to_.py
@@ -1,0 +1,25 @@
+"""add stripe_webhook_endpoint_secret to PaymentProvider
+
+Revision ID: 5e536de32a31
+Revises: db265b2a50e1
+Create Date: 2020-09-21 11:16:08.945258
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '5e536de32a31'
+down_revision = 'db265b2a50e1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("payment_provider") as batch_op:
+        batch_op.add_column(sa.Column('stripe_webhook_endpoint_secret', sa.String(), nullable=True))
+
+
+def downgrade():
+    pass

--- a/migrations/versions/bca9e879f754_add_stripe_webhook_endpoint_id_to_.py
+++ b/migrations/versions/bca9e879f754_add_stripe_webhook_endpoint_id_to_.py
@@ -1,0 +1,24 @@
+"""add stripe_webhook_endpoint_id to PaymentProvider
+
+Revision ID: bca9e879f754
+Revises: 5e536de32a31
+Create Date: 2020-09-21 11:27:02.928338
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'bca9e879f754'
+down_revision = '5e536de32a31'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    with op.batch_alter_table("payment_provider") as batch_op:
+        batch_op.add_column(sa.Column('stripe_webhook_endpoint_id', sa.String(), nullable=True))
+
+
+def downgrade():
+    pass

--- a/subscribie/blueprints/admin/templates/admin/connect_stripe_manually.html
+++ b/subscribie/blueprints/admin/templates/admin/connect_stripe_manually.html
@@ -23,7 +23,7 @@
           <div class="alert {% if stripe_connected %}alert-success{% else %}alert-light{% endif %}">
             <p><strong>Status: </strong>
               {% if stripe_connected %}
-                Stripe is already connected!
+                Stripe is connected!
               {% else %}
                 Stripe isn't yet configured, use the form below.
               {% endif %}

--- a/subscribie/models.py
+++ b/subscribie/models.py
@@ -163,6 +163,8 @@ class PaymentProvider(database.Model):
     stripe_active = database.Column(database.Boolean())
     stripe_publishable_key = database.Column(database.String())
     stripe_secret_key = database.Column(database.String())
+    stripe_webhook_endpoint_secret = database.Column(database.String())
+    stripe_webhook_endpoint_id = database.Column(database.String())
 
 class Page(database.Model):
     __tablename__ = 'page'


### PR DESCRIPTION
Fix #162 

The migration from Stripe legacy version of Checkout to the new version.
This allows more payment types to be accepted (Google & Apple pay) and Strong Customer Authentication (SCA).

https://stripe.com/docs/payments/checkout/migration
![image](https://user-images.githubusercontent.com/1718624/93779352-ca365c00-fc1e-11ea-8c5f-1e06d392786e.png)
