### PR TITLE
Test adding choice group as admin

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+. venv/bin/activate
+python -m pytest

--- a/subscribie/blueprints/admin/option.py
+++ b/subscribie/blueprints/admin/option.py
@@ -2,10 +2,9 @@ from . import admin
 from subscribie.auth import login_required
 from subscribie.forms import OptionForm
 from subscribie.models import ChoiceGroup, Option
+from subscribie.database import database
 from flask import request, render_template, url_for, flash, redirect
 from flask_sqlalchemy import SQLAlchemy
-
-database = SQLAlchemy()
 
 
 @admin.route("/add-option/choice_group_id/<choice_group_id>", methods=["GET", "POST"])

--- a/tests/test_subscribie.py
+++ b/tests/test_subscribie.py
@@ -62,6 +62,19 @@ def test_admin_cal_add_plan(session, app, client, admin_session):
         assert 'name="sell_price-0" value="5.0"' in req.data.decode("utf-8")
 
 
+def test_admin_can_add_choice_group(session, app, client, admin_session):
+    user = User.query.filter_by(email="admin@example.com").first()
+    with user_set(app, user):
+        req = client.post(
+            "/admin/add-choice-group",
+            follow_redirects=True,
+            data={
+                "title": "Colour choice",
+            },
+        )
+        assert "Colour choice" in req.data.decode("utf-8")
+
+
 @pytest.fixture(scope="function")
 def admin_session(client, with_shop_owner):
     user = User.query.filter_by(email="admin@example.com").first()

--- a/tests/test_subscribie.py
+++ b/tests/test_subscribie.py
@@ -75,6 +75,30 @@ def test_admin_can_add_choice_group(session, app, client, admin_session):
         assert "Colour choice" in req.data.decode("utf-8")
 
 
+def test_admin_can_add_an_option_to_a_choice_group(session, app, client, admin_session):
+    user = User.query.filter_by(email="admin@example.com").first()
+    with user_set(app, user):
+        # First add a choice group (will have an id of 1)
+        req = client.post(
+            "/admin/add-choice-group",
+            follow_redirects=True,
+            data={
+                "title": "Colour choice",
+            },
+        )
+
+        # Now add an option to this new choice group
+        req = client.post(
+            "/admin/add-option/choice_group_id/1",
+            follow_redirects=True,
+            data={
+                "title": "Light Blue",
+            },
+        )
+
+        assert "Light Blue" in req.data.decode("utf-8")
+
+
 @pytest.fixture(scope="function")
 def admin_session(client, with_shop_owner):
     user = User.query.filter_by(email="admin@example.com").first()


### PR DESCRIPTION
Fix the choice group option not saving- due to incorrect SqlAlchemy import https://github.com/Subscribie/subscribie/pull/339/commits/575d146b590bcd1094bd3a69c11012521fcd4732

Added test. However one caveat is that the test database session would not catch this bug given it's a legitimate database session and the data does persist during the pytest fixture.

Thanks @Anpoli13 for reporting
