### PR TITLE
363 scalable share repo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,10 @@
 #Only values in uppercase are actually stored in the config object later on. So make sure to use uppercase letters for your config keys.
 
 FLASK_ENV=live
-SUBSCRIBIE_REPO_DIRECTORY=/path/to/repo
+# For testing this repo in isolation, SUBSCRIBIE_REPO_DIRECTORY can be './'
+# for production, SUBSCRIBIE_REPO_DIRECTORY should be wherever the repo
+# is cloned to
+SUBSCRIBIE_REPO_DIRECTORY=./
 SQLALCHEMY_TRACK_MODIFICATIONS=False
 SQLALCHEMY_DATABASE_URI="sqlite:///../../data.db"
 SECRET_KEY="random string. e.g. echo -e 'from os import urandom\\nprint urandom(25)' | python"

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 #Only values in uppercase are actually stored in the config object later on. So make sure to use uppercase letters for your config keys.
 
 FLASK_ENV=live
+SUBSCRIBIE_REPO_DIRECTORY=/path/to/repo
 SQLALCHEMY_TRACK_MODIFICATIONS=False
 SQLALCHEMY_DATABASE_URI="sqlite:///../../data.db"
 SECRET_KEY="random string. e.g. echo -e 'from os import urandom\\nprint urandom(25)' | python"

--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,6 @@ DB_FULL_PATH="../../data.db"
 MODULES_PATH="./modules/"
 TEMPLATE_BASE_DIR="./subscribie/themes/"
 THEME_NAME="jesmond"
-STATIC_FOLDER="./subscribie/themes/theme-jesmond/static/"
 UPLOADED_IMAGES_DEST="./subscribie/static/"
 UPLOADED_FILES_DEST="./subscribie/uploads/"
 # Default 50Mb upload limit

--- a/.github/workflows/pr-demo-deploy.yml
+++ b/.github/workflows/pr-demo-deploy.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   deploy-pr:
     runs-on: ubuntu-20.04
+    timeout-minutes: 15
     environment: testing
     steps:
       - name: Dump context

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ To rebuild the latest container, stop docker compose then do: `docker-compose bu
 Change:
 
 - `THEME_NAME="jesmond"` to `THEME_NAME="builder"`
-- `STATIC_FOLDER="./subscribie/themes/theme-jesmond/static/"` to `STATIC_FOLDER="./subscribie/themes/theme-builder/static/"`
 - **(optional)** change `TEMPLATE_BASE_DIR` if you want to store themes in a different directory.
 
 2. Stop & start subscribie

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,6 @@ sed -i 's#SERVER_NAME.*##g' .env
 
 # Set static dir
 sed -i 's#TEMPLATE_BASE_DIR.*#TEMPLATE_BASE_DIR=/usr/src/app/subscribie/subscribie/themes/#g' .env
-sed -i 's#STATIC_FOLDER.*#STATIC_FOLDER=/usr/src/app/subscribie/subscribie/themes/theme-jesmond/static/#g' .env
 sed -i 's#UPLOADED_IMAGES_DEST.*#UPLOADED_IMAGES_DEST=/usr/src/app/subscribie/subscribie/static/#g' .env
 
 flask db upgrade

--- a/subscribie.wsgi
+++ b/subscribie.wsgi
@@ -1,3 +1,19 @@
+import sys
+import os
+import logging
+
+PYTHON_LOG_LEVEL = os.getenv('PYTHON_LOG_LEVEL', logging.INFO)
+
+logging.basicConfig(level=PYTHON_LOG_LEVEL)
+
+def load():
+    paths = [os.getenv('PYTHON_PATH_INJECT')]
+    for p in paths:
+        logging.info(f"Injecting python path {p}")
+        sys.path.insert(0, p)
+
+load()
+
 from subscribie import create_app
 
 application = create_app()

--- a/subscribie/blueprints/admin/__init__.py
+++ b/subscribie/blueprints/admin/__init__.py
@@ -831,11 +831,7 @@ def upload_logo():
             flash("File required")
         else:
             filename = images.save(f)
-            # symlink to active theme static directory
-            img_src = "".join([current_app.config["UPLOADED_IMAGES_DEST"], filename])
-            link = "".join([current_app.config["STATIC_FOLDER"], filename])
-            os.symlink(img_src, link)
-            src = url_for("static", filename=filename)
+            src = url_for("views.custom_static", filename=filename)
             company.logo_src = src
             database.session.commit()
             flash("Logo has been uploaded")

--- a/subscribie/blueprints/admin/__init__.py
+++ b/subscribie/blueprints/admin/__init__.py
@@ -351,13 +351,7 @@ def edit():
             if f:
                 images = UploadSet("images", IMAGES)
                 filename = images.save(f)
-                # symlink to active theme static directory
-                img_src = "".join(
-                    [current_app.config["UPLOADED_IMAGES_DEST"], filename]
-                )
-                link = "".join([current_app.config["STATIC_FOLDER"], filename])
-                os.symlink(img_src, link)
-                src = url_for("static", filename=filename)
+                src = url_for("views.custom_static", filename=filename)
                 draftPlan.primary_icon = src
         database.session.commit()  # Save
         flash("Plan(s) updated.")

--- a/subscribie/blueprints/admin/__init__.py
+++ b/subscribie/blueprints/admin/__init__.py
@@ -424,11 +424,7 @@ def add_plan():
         if f:
             images = UploadSet("images", IMAGES)
             filename = images.save(f)
-            # symlink to active theme static directory
-            img_src = "".join([current_app.config["UPLOADED_IMAGES_DEST"], filename])
-            link = "".join([current_app.config["STATIC_FOLDER"], filename])
-            os.symlink(img_src, link)
-            src = url_for("static", filename=filename)
+            src = url_for("views.custom_static", filename=filename)
             draftPlan.primary_icon = src
 
         database.session.commit()

--- a/subscribie/views.py
+++ b/subscribie/views.py
@@ -26,6 +26,7 @@ from flask import (
     jsonify,
     current_app,
     g,
+    send_from_directory,
 )
 import flask
 
@@ -80,6 +81,11 @@ def inject_template_globals():
     plans = Plan.query.filter_by(archived=0)
     pages = Page.query.all()
     return dict(company=company, integration=integration, plans=plans, pages=pages)
+
+
+@bp.route("/cdn/<path:filename>")
+def custom_static(filename):
+    return send_from_directory(current_app.config["UPLOADED_IMAGES_DEST"], filename)
 
 
 def redirect_url():

--- a/subscribie/views.py
+++ b/subscribie/views.py
@@ -52,8 +52,18 @@ from .database import database
 from flask_mail import Mail, Message
 import json
 import backoff
+from flask_migrate import upgrade
 
 bp = Blueprint("views", __name__, url_prefix=None)
+
+
+@bp.before_app_first_request
+def migrate_database():
+    """Migrate database when app first boots"""
+    print("#" * 233)
+    upgrade(
+        directory=Path(current_app.config["SUBSCRIBIE_REPO_DIRECTORY"] + "/migrations")
+    )
 
 
 @bp.before_app_request

--- a/tests/browser-automated-tests-playwright/index.js
+++ b/tests/browser-automated-tests-playwright/index.js
@@ -191,6 +191,11 @@ async function test_connect_to_stripe_connect()  {
     console.log("Continuing regardless");
   }
 
+  console.log("Announce stripe account manually visiting announce url. In prod this is called via uwsgi cron");
+  await page.goto(PLAYWRIGHT_HOST + '/admin/announce-stripe-connect');
+  const contentStripeAccountAnnounced = await page.evaluate(() => document.body.textContent.indexOf("Announced Stripe connect account"));
+  assert(contentStripeAccountAnnounced > -1);
+
   await browser.close();
 }
 


### PR DESCRIPTION
Fix #363
Ref https://github.com/Subscribie/subscribie-deployer/issues/12 

- subscribie repo is no longer cloned for every new site
- `subscribie.wsgi` updated to inject path of shared subscribie repo (because the repo is now shared at path `PYTHON_PATH_INJECT`)
- `STATIC_FOLDER` removed in favour of blueprint route `@bp.route("/cdn/<path:filename>")`
- Added `@bp.before_app_first_request migrate_database` which migrates the database upon first instantiation of the app (making live updates/reloads possible) 