### PR TITLE
Fix #408 stripe kyc card_paryments capability enable api change

### DIFF
--- a/subscribie/blueprints/admin/__init__.py
+++ b/subscribie/blueprints/admin/__init__.py
@@ -22,6 +22,7 @@ from subscribie.utils import (
     get_stripe_connect_account,
     create_stripe_connect_account,
     get_stripe_connect_account_id,
+    modify_stripe_account_capability,
 )
 from subscribie.forms import (
     TawkConnectForm,
@@ -502,6 +503,14 @@ def stripe_connect():
 
     # Setup Stripe webhook endpoint if it dosent already exist
     if account:
+        # Attempt to Updates an existing Account Capability to accept card payments
+        try:
+            account = get_stripe_connect_account()
+            modify_stripe_account_capability(account.id)
+        except Exception as e:
+            logging.info("Could not update card_payments capability for account")
+            logging.info(e)
+
         try:
             stripe_express_dashboard_url = stripe.Account.create_login_link(
                 account.id

--- a/subscribie/blueprints/admin/templates/admin/settings/stripe/stripe_connect.html
+++ b/subscribie/blueprints/admin/templates/admin/settings/stripe/stripe_connect.html
@@ -56,12 +56,12 @@
 
          {% elif account.charges_enabled and account.payouts_enabled is sameas False %}
             <div class="alert alert-warning" role="alert">
-                Payouts to your bank account are not active yet. But don't worry, 
-                you can still accept live payments on your shop right now. Stripe
-                will safley hold your funds until your account is verified.<br />
-                Please check back here after a short while (30 mins) and Stripe 
-                will ask you to upload verification documents, by clicking 
-                'Setup payouts on stripe' again to continue where you left off.
+                Payouts to your bank account are not active yet.
+                Stripe needs you to provide identification.<br />
+                Please check back here after a short while (5 mins) and Stripe
+                will ask you to upload verification documents. Click
+                'Setup payouts on stripe' again and you'll be asked to provide documents
+                (this is to reduce fraud and protect you and your customers).
                 <br />
                 <p>
                     If you have recently uploaded these documents, please give Stripe some time

--- a/subscribie/utils.py
+++ b/subscribie/utils.py
@@ -95,3 +95,9 @@ def format_to_stripe_interval(plan: str):
     else:
         return ""
     return plan
+
+
+def modify_stripe_account_capability(account_id):
+    """Request (again) card_payments capability after kyc onboarding
+    is complete"""
+    stripe.Account.modify_capability(account_id, "card_payments", requested=True)

--- a/tests/browser-automated-tests-playwright/index.js
+++ b/tests/browser-automated-tests-playwright/index.js
@@ -129,6 +129,16 @@ async function test_connect_to_stripe_connect()  {
         await page.click('text="Next"');
       }
       
+      // If on the document verification page, only email and phone number needed to login
+      // so press next. This is confusing because "Tell us a few details about yourself" also
+      // appears on an earlier onboarding step (before doing document verification)
+      if (contentStripePage.indexOf('Tell us a few details about yourself') > -1)
+      {
+        let numInputs = await page.evaluate(() => document.forms[0].querySelectorAll('input').length);
+        if (numInputs == 2) {
+            await page.click('text="Next"');
+        }
+      }
 
       // Stripe onboarding personal details step
       if (contentStripePage.indexOf('Tell us a few details about yourself') > -1 ) {


### PR DESCRIPTION
Fixes the error: "You cannot create a charge on a connected account without the `card_payments` capability enabled."

due to https://stripe.com/en-br/guides/important-update-for-connect

- also fixes deploy pr preview tests
Ref #408 