### PR TITLE
Fix #441 make my subscribers page load faster

### DIFF
--- a/subscribie/blueprints/admin/templates/admin/subscribers.html
+++ b/subscribie/blueprints/admin/templates/admin/subscribers.html
@@ -56,6 +56,10 @@
               {% if person.subscriptions %}
               <ul class="list-unstyled">
                 {% for subscription in person.subscriptions %}
+                    {% if subscription.plan.requirements.subscription %}
+                    {# if plan is a subscription, get its live subscription status #}
+                      {% set ns = namespace(stripe_subscription_status = subscription_status(subscription.stripe_external_id)) %}
+                    {% endif %}
                     <li>
                         <div class="card">
                             <ul class="list-unstyled px-2">
@@ -94,7 +98,7 @@
                                     </span>
                                     <li><strong>Status: </strong>
                                         {% if subscription.plan.requirements.subscription %}
-                                            {{subscription_status(subscription.stripe_external_id)}}
+                                            {{ ns.stripe_subscription_status }}
                                         {% else %}
                                             Paid
                                         {% endif %}
@@ -112,15 +116,15 @@
                                         {% endif %}
                                     </li>
                                     <li><strong>Actions: </strong>
-                                        {% if subscription.stripe_external_id %}
-                                            {% if subscription_status(subscription.stripe_external_id) == 'Active' %}
+                                        {% if subscription.plan.requirements.subscription %}
+                                            {% if ns.stripe_subscription_status == 'Active' %}
                                                 <a href="{{ url_for("admin.pause_stripe_subscription",
                                                 subscription_id=subscription.stripe_external_id,
                                                 goback=1) }}">
                                                     Pause
                                                 </a> | 
                                             {% endif %}
-                                            {% if subscription_status(subscription.stripe_external_id) == 'Paused' %}
+                                            {% if ns.stripe_subscription_status == 'Paused' %}
                                                 <a href="{{ url_for("admin.resume_stripe_subscription",
                                                 subscription_id=subscription.stripe_external_id,
                                                 goback=1) }}">


### PR DESCRIPTION
Ref #441 
- This reduced load time ~50% by removing repeated api requests. The updates are still live.
- A cache will be added in another PR.

Thanks @schumskie for raising