### PR TITLE
Fix #514 custom pages now saved to CUSTOM_PAGES_PATH

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ DB_FULL_PATH="/tmp/data.db"
 MODULES_PATH="./modules/"
 TEMPLATE_BASE_DIR="./subscribie/themes/"
 THEME_NAME="jesmond"
+CUSTOM_PAGES_PATH="./subscribie/custom_pages/"
 UPLOADED_IMAGES_DEST="./subscribie/static/"
 UPLOADED_FILES_DEST="./subscribie/uploads/"
 # Default 50Mb upload limit

--- a/subscribie/Template.py
+++ b/subscribie/Template.py
@@ -41,7 +41,14 @@ def load_theme(app):
     app.config["THEME_PATH"] = themePath
 
     my_loader = jinja2.ChoiceLoader(
-        [jinja2.FileSystemLoader(str(themePath)), app.jinja_loader]
+        [
+            # First attempt to get theme file from active theme
+            jinja2.FileSystemLoader(str(themePath)),
+            # Check if template is found in CUSTOM_PAGES_PATH
+            jinja2.FileSystemLoader(str(app.config.get("CUSTOM_PAGES_PATH", None))),
+            # Finally fallback to flask default template directory
+            app.jinja_loader,
+        ]
     )
     app.jinja_loader = my_loader
     app.static_folder = str(staticFolder)

--- a/subscribie/blueprints/pages/__init__.py
+++ b/subscribie/blueprints/pages/__init__.py
@@ -51,7 +51,7 @@ def delete_page_by_path(path):
         )
     # Perform template file deletion
     templateFile = path + ".html"
-    templateFilePath = Path(str(current_app.config["THEME_PATH"]), templateFile)
+    templateFilePath = Path(str(current_app.config["CUSTOM_PAGES_PATH"]), templateFile)
     try:
         templateFilePath.unlink()
     except FileNotFoundError:
@@ -81,7 +81,9 @@ def edit_page(path):
     if request.method == "GET":
         # Get page file contents
         template_file = page.template_file
-        with open(Path(str(current_app.config["THEME_PATH"]), template_file)) as fh:
+        with open(
+            Path(str(current_app.config["CUSTOM_PAGES_PATH"]), template_file)
+        ) as fh:
             rawPageContent = fh.read()
         return render_template(
             "edit_page.html", rawPageContent=rawPageContent, pageTitle=page.page_name
@@ -114,7 +116,7 @@ def edit_page(path):
             oldTemplateFile = path + ".html"
             # Rename old template file .old
             oldTemplatePath = Path(
-                str(current_app.config["THEME_PATH"]), oldTemplateFile
+                str(current_app.config["CUSTOM_PAGES_PATH"]), oldTemplateFile
             )
             oldTemplatePath.replace(
                 Path(str(current_app.config["THEME_PATH"]), oldTemplateFile + ".old")
@@ -168,7 +170,12 @@ def save_new_page():
     # Check page doesnt already exist
     page = Page.query.filter_by(path=pageName).first()
     if page is not None:
-        flash(Markup(f'The page <a href="/{pageName}">{pageName}</a> already exists'))
+        custom_page_url = url_for("views.custom_page", path=pageName)
+        flash(
+            Markup(
+                f"The page <a href='{custom_page_url}'>{pageName}</a> already exists"
+            )
+        )
         return redirect(url_for("pages.edit_pages_list"))
 
     # Add new page
@@ -181,7 +188,7 @@ def save_new_page():
 
     # Writeout template_file to file
     with open(
-        Path(str(current_app.config["THEME_PATH"]), template_file.lower()), "w"
+        Path(str(current_app.config["CUSTOM_PAGES_PATH"]), template_file.lower()), "w"
     ) as fh:
         full_page = page_body
         fh.write(full_page)

--- a/subscribie/views.py
+++ b/subscribie/views.py
@@ -139,7 +139,7 @@ def custom_page(path):
         return redirect
     try:
         with open(
-            Path(str(current_app.config["THEME_PATH"]), page.template_file)
+            Path(str(current_app.config["CUSTOM_PAGES_PATH"]), page.template_file)
         ) as fh:
             body = fh.read()
     except FileNotFoundError as e:


### PR DESCRIPTION
Ref #514 

- Introduced new env setting `CUSTOM_PAGES_PATH` which is a path to custom pages (defaults to ./subscribie/custom_pages) see [`.env.example`](https://github.com/Subscribie/subscribie/pull/515/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR17)
- [Subscribie deployer](https://github.com/Subscribie/subscribie-deployer/blob/master/main.py#L71) will need updating to mkdir and set `CUSTOM_PAGES_PATH` config [Fixed](https://github.com/Subscribie/subscribie-deployer/commit/b63ef6cb8842460120fa2a76f0668e1f15441c0e)