### PR TITLE
wip #516 shop owner can add cancel_at

### DIFF
--- a/migrations/versions/084669093d74_add_stripe_cancel_at_to_subscription_.py
+++ b/migrations/versions/084669093d74_add_stripe_cancel_at_to_subscription_.py
@@ -1,0 +1,25 @@
+"""add stripe_cancel_at to Subscription model
+
+Revision ID: 084669093d74
+Revises: b28487bfca0f
+Create Date: 2021-05-04 22:55:42.753614
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "084669093d74"
+down_revision = "b28487bfca0f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("subscription") as batch_op:
+        batch_op.add_column(sa.Column("stripe_cancel_at", sa.String(), nullable=True))
+
+
+def downgrade():
+    pass

--- a/migrations/versions/b28487bfca0f_merge_c39_add_cancel_at_and_d7b_add_.py
+++ b/migrations/versions/b28487bfca0f_merge_c39_add_cancel_at_and_d7b_add_.py
@@ -1,0 +1,24 @@
+"""Merge c39 add cancel_at and d7b add stripe_status
+
+Revision ID: b28487bfca0f
+Revises: c39dd6d1961f, d7b1aaee84ab
+Create Date: 2021-05-03 14:57:43.633763
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b28487bfca0f'
+down_revision = ('c39dd6d1961f', 'd7b1aaee84ab')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/migrations/versions/c39dd6d1961f_add_cancel_at_to_plan_model.py
+++ b/migrations/versions/c39dd6d1961f_add_cancel_at_to_plan_model.py
@@ -1,0 +1,25 @@
+"""add cancel_at to plan model
+
+Revision ID: c39dd6d1961f
+Revises: c751fe53a042
+Create Date: 2021-04-25 15:29:11.034541
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "c39dd6d1961f"
+down_revision = "c751fe53a042"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("plan") as batch_op:
+        batch_op.add_column(sa.Column("cancel_at", sa.String(), nullable=True))
+
+
+def downgrade():
+    pass

--- a/seed.sql
+++ b/seed.sql
@@ -2,7 +2,7 @@ INSERT INTO user (id, email, password) VALUES
 (1, 'admin@example.com', 'pbkdf2:sha256:150000$w0mLxLJU$e6f21a4b45a0d10286766f33057834949148eb2b3ecc4ec1a136d619f82034d0'); -- password
 
 INSERT INTO company (id, created_at, name, slogan) VALUES 
-(1, datetime(), "Soap Subscription", "Sqeaky clean!");
+(1, datetime(), "Soap Subscription "|| DATE(), "Sqeaky clean!");
 
 INSERT INTO category(id, uuid, created_at, name) VALUES
 (1, "7085d61d-c84d-4951-a824-aa27c7e21086", datetime(), "Make your choice");

--- a/subscribie/blueprints/admin/__init__.py
+++ b/subscribie/blueprints/admin/__init__.py
@@ -622,6 +622,19 @@ def add_plan():
         else:
             draftPlan.private = 0
 
+        # If cancel_at_set is set,
+        # get date and time and convert to timestamp
+        if request.form.get("cancel_at_set-0", None):
+            cancel_at_date = datetime.strptime(
+                request.form.get("cancel_at_date", None), "%Y-%m-%d"
+            )
+            cancel_at_time = datetime.strptime(
+                request.form.get("cancel_at_time", None), "%H:%M"
+            )
+
+            cancel_at = datetime.combine(cancel_at_date.date(), cancel_at_time.time())
+            draftPlan.cancel_at = cancel_at.timestamp()
+
         database.session.commit()
         flash("Plan added.")
         return redirect(url_for("admin.dashboard"))

--- a/subscribie/blueprints/admin/__init__.py
+++ b/subscribie/blueprints/admin/__init__.py
@@ -633,7 +633,7 @@ def add_plan():
             )
 
             cancel_at = datetime.combine(cancel_at_date.date(), cancel_at_time.time())
-            draftPlan.cancel_at = cancel_at.timestamp()
+            draftPlan.cancel_at = int(float(cancel_at.timestamp()))
 
         database.session.commit()
         flash("Plan added.")

--- a/subscribie/blueprints/admin/__init__.py
+++ b/subscribie/blueprints/admin/__init__.py
@@ -1045,6 +1045,10 @@ def subscribers():
 def refresh_subscriptions():
     update_stripe_subscription_statuses()
     if request.referrer is not None:
+        flash("Subscription statuses have been refreshed.")
+        flash(
+            "Note: This is done automatically every 10 minutes so you don't need to keep clicking refresh."  # noqa
+        )
         return redirect(request.referrer)
 
 

--- a/subscribie/blueprints/admin/__init__.py
+++ b/subscribie/blueprints/admin/__init__.py
@@ -93,6 +93,11 @@ def currencyFormat(value):
     return "£{:,.2f}".format(value)
 
 
+@admin.app_template_filter()
+def timestampToDate(timestamp):
+    return datetime.fromtimestamp(int(timestamp)).strftime("%Y-%m-%d")
+
+
 def store_stripe_transaction(stripe_external_id):
     """Store Stripe invoice payment in transactions table"""
     stripe.api_key = get_stripe_secret_key()

--- a/subscribie/blueprints/admin/templates/admin/add_plan.html
+++ b/subscribie/blueprints/admin/templates/admin/add_plan.html
@@ -215,6 +215,29 @@
                               Then, you can send a link to your customer(s) to sign-up to the private plan.
                               </small>
             </div>
+
+            <div class="form-group ">
+                  <div class="form-check">
+                    <input type="checkbox" value="yes" class="form-check-input toggle" name="cancel_at_set-0" id="cancel_at_set-0">
+                    <label class="form-check-label font-weight-bolder" for="cancel_at_set-0">Cancel at</label>
+                  </div>
+                  <small class="form-text text-muted">
+                    Cancel all subscriptions to this plan at this date / time. This is useful if you run a
+                    membership style organisation with seasons (such as a Football club).
+                  </small>
+            </div>
+            <div class="form-group extra_fields" id="cancel_at" >
+              <label for="cancel_at-0" class="col-form-label font-weight-bolder">Date &amp; time to cancel</label>
+              <label class="form-check-label font-weight-bolder" for="cancel_at_date">Cancel at</label>
+              <input type="date" class="form-control" name="cancel_at_date" id="cancel_at_date">
+              <small class="form-text text-muted mb-2">
+                Date (e.g. 30th June 2022)
+              </small>
+              <input type="time" class="form-control" name="cancel_at_time" value="00:00" id="cancel_at_time">
+              <small class="form-text text-muted">
+                Time (e.g. midnight)
+              </small>
+            </div>
           </fieldset>
         
           <button type="submit" class="disable-on-click btn btn-primary btn-block my-3 mx-auto">Save</button>

--- a/subscribie/blueprints/admin/templates/admin/add_plan.html
+++ b/subscribie/blueprints/admin/templates/admin/add_plan.html
@@ -227,7 +227,7 @@
                   </small>
             </div>
             <div class="form-group extra_fields" id="cancel_at" >
-              <label for="cancel_at-0" class="col-form-label font-weight-bolder">Date &amp; time to cancel</label>
+              <label for="cancel_at-0" class="col-form-label font-weight-bolder">Date &amp; time to</label>
               <label class="form-check-label font-weight-bolder" for="cancel_at_date">Cancel at</label>
               <input type="date" class="form-control" name="cancel_at_date" id="cancel_at_date">
               <small class="form-text text-muted mb-2">
@@ -248,5 +248,22 @@
 
     </div>
   </div><!-- end .section -->
+ <script>
+ var checkBox = document.querySelector('input[id="cancel_at_set-0"]');
+ var dateInput = document.querySelector('input[id="cancel_at_date"]');
+
+ function toggleRequired() {
+
+    if (dateInput.hasAttribute('required') !== true) {
+        dateInput.setAttribute('required','required');
+    }
+
+    else {
+        dateInput.removeAttribute('required');
+    }
+ }
+
+ checkBox.addEventListener('change',toggleRequired,false);
+</script>
 </main>
 {% endblock body %}

--- a/subscribie/blueprints/admin/templates/admin/layout.html
+++ b/subscribie/blueprints/admin/templates/admin/layout.html
@@ -158,8 +158,12 @@
       }
       document.getElementById('save').disabled=true;
     }
-    form = document.getElementById('plansForm');
-    form.addEventListener('submit', handlePlansForm);
+    try {
+      form = document.getElementById('plansForm');
+      form.addEventListener('submit', handlePlansForm);
+    } catch (error) {
+      console.log(error);
+    }
   </script>
   <!-- end plan add/edit validation -->
 

--- a/subscribie/blueprints/admin/templates/admin/layout.html
+++ b/subscribie/blueprints/admin/templates/admin/layout.html
@@ -167,6 +167,25 @@
   </script>
   <!-- end plan add/edit validation -->
 
+  <script>
+  <!-- disable on click handler -->
+  elements = document.querySelectorAll('button.disable-on-click');
+
+  function disableElement(e) {
+    e.target.disabled = true;
+    window.setTimeout(enableElement, 10000, e);
+  }
+
+  function enableElement(e) {
+    e.target.disabled = false;
+  }
+
+  for (var i=0;i<elements.length;i++) {
+    elements[i].addEventListener('click', disableElement);
+  }
+  </script>
+  <!-- end disable-on-click handler -->
+
   <!-- Bootstrap jQuery scripts -->
   <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>

--- a/subscribie/blueprints/admin/templates/admin/subscribers.html
+++ b/subscribie/blueprints/admin/templates/admin/subscribers.html
@@ -104,6 +104,12 @@
                                             Paid
                                         {% endif %}
                                     </li>
+                                    {% if subscription.stripe_cancel_at %}
+                                      <strong>Automatically Cancels at:</strong>
+                                      {{ subscription.stripe_cancel_at | timestampToDate }}
+                                    {% endif %}
+                                    <li>
+                                    </li>
                                     <li>
                                         {% if subscription.plan.requirements and subscription.plan.requirements.note_to_seller_required %}
                                             <details open>

--- a/subscribie/blueprints/admin/templates/admin/subscribers.html
+++ b/subscribie/blueprints/admin/templates/admin/subscribers.html
@@ -20,10 +20,10 @@
         {% if show_active %}
           <a href="{{url_for('admin.subscribers')}}" id="show-active-subscribers" class="btn btn-primary active">Show all</a>
         {% else %}
-          <a href="{{url_for('admin.subscribers', action='show_active')}}" id="show-active-subscribers" class="btn btn-primary">Show Active</a>
+          <a href="{{url_for('admin.subscribers', action='show_active')}}" id="show-active-subscribers" class="btn btn-primary ">Show Active</a>
       {%endif %}
       <a href="{{url_for('admin.archived_subscribers')}}" class="btn btn-primary">Show Archived</a>
-      <a href="{{url_for('admin.refresh_subscriptions')}}" title="Get latest subscription statuses (active/paused/inactive)" class="btn btn-primary">Refresh Subscriptions</a>
+      <button id="refresh_subscriptions" title="Get latest subscription statuses (active/paused/inactive)" class="btn btn-primary disable-on-click">Refresh Subscriptions</button>
        </div>
       <table class="table mobile-optimised">
         <thead>
@@ -158,6 +158,17 @@
 document.getElementById('show-active-subscribers').addEventListener('click', function(e) {
   e.target.textContent = "Please wait...";
 });
+
+{# Refresh subscription statuses when button clicked #}
+btnRefreshSubscriptions = document.getElementById('refresh_subscriptions');
+
+btnRefreshSubscriptions.addEventListener('click', refreshSubscriptionStatuses);
+
+function refreshSubscriptionStatuses() {
+  fetch("{{ url_for('admin.refresh_subscriptions') }}")
+  .then(response => { document.location = "{{ url_for('admin.refresh_subscriptions') }}" });
+}
+{# End Refresh subscription statuses when button clicked #}
 
 </script>
 

--- a/subscribie/blueprints/checkout/__init__.py
+++ b/subscribie/blueprints/checkout/__init__.py
@@ -451,7 +451,7 @@ def create_subscription(
         stripe.api_key = get_stripe_secret_key()
         connect_account_id = get_stripe_connect_account_id()
         if subscription.plan.cancel_at:
-            cancel_at = int(float(subscription.plan.cancel_at))
+            cancel_at = subscription.plan.cancel_at
             try:
                 stripe.Subscription.modify(
                     sid=subscription.stripe_subscription_id,

--- a/subscribie/blueprints/checkout/__init__.py
+++ b/subscribie/blueprints/checkout/__init__.py
@@ -297,7 +297,7 @@ def stripe_create_checkout_session():
         if plan.requirements.subscription:
             plan_name = "(Up-front fee) " + plan_name
 
-        tax_rates = [tax_rate.stripe_tax_rate_id] if charge_vat == True else []
+        tax_rates = [tax_rate.stripe_tax_rate_id] if charge_vat is True else []
         line_items.append(
             {
                 "tax_rates": tax_rates,
@@ -456,8 +456,10 @@ def create_subscription(
                 stripe.Subscription.modify(
                     sid=subscription.stripe_subscription_id,
                     stripe_account=connect_account_id,
-                    metadata={"cancel_at": cancel_at},
+                    cancel_at=cancel_at,
                 )
+                subscription.stripe_cancel_at = cancel_at
+                database.session.commit()
             except Exception as e:  # noqa
                 logging.error("Could not set cancel_at: {e}")
 

--- a/subscribie/forms.py
+++ b/subscribie/forms.py
@@ -74,6 +74,9 @@ class PlansForm(StripWhitespaceForm):
         FileField(validators=[FileAllowed(images, "Images only!")]), min_entries=1
     )
     position = FieldList(IntegerField("Position", [validators.optional()], default=0))
+    cancel_at = FieldList(
+        StringField("Cancel at", [validators.optional()], default=False)
+    )
     description = FieldList(
         StringField("Description", [validators.optional()], default=False)
     )

--- a/subscribie/models.py
+++ b/subscribie/models.py
@@ -124,6 +124,11 @@ class Subscription(database.Model):
     stripe_subscription_id = database.Column(database.String())
     stripe_external_id = database.Column(database.String())
     stripe_status = database.Column(database.String())
+    # stripe_cancel_at is the 'live' setting (which may change)
+    # and must be checked via cron/webhooks. Plan.cancel_at allows
+    # a shop owner to set a cancel_at date before subscribers sign-up,
+    # which creates subscriptions.
+    stripe_cancel_at = database.Column(database.String(), default=False)
 
     def stripe_subscription_active(self):
         if self.stripe_subscription_id is not None:

--- a/subscribie/models.py
+++ b/subscribie/models.py
@@ -246,6 +246,7 @@ class Plan(database.Model, HasArchived):
     category_uuid = database.Column(database.Integer, ForeignKey("category.uuid"))
     category = relationship("Category", back_populates="plans")
     private = database.Column(database.Boolean(), default=0)
+    cancel_at = database.Column(database.String(), default=False)
 
 
 class Category(database.Model):

--- a/subscribie/themes/theme-jesmond/jesmond/choose.html
+++ b/subscribie/themes/theme-jesmond/jesmond/choose.html
@@ -85,6 +85,9 @@
                   <i class="fas fa-check-circle pr-2 mt-1"></i><p>{{ sellingPoint.point|safe }}</p>
                 </div>
                 {% endfor %}
+                {% if plan.cancel_at %}
+                  <small>Automatically cancels on: {{ plan.cancel_at | timestampToDate }}</small>
+                {% endif %}
               </div>
 
               <div class="card-footer">
@@ -108,7 +111,6 @@
                     </div>
                   </div>
                 {% endif %}
-
                 {% if plan.choice_groups %}
                   <a href="{{ url_for('views.set_options', plan_uuid=plan.uuid) }}" class="btn-outlined-lg btn-block">
                     Choose


### PR DESCRIPTION
See: #516 
stipe webhook enforces cancel_at upon subscription creation

When shop owner creates a subscription with a cancel at date , when someone signs up, the stripe webhook (use Stripe CLI locally to test) will update the subscription to set the cancel_at attribute on the subscription object (see Stripe CLI, and also check on the stripe dashboard) 

Shop owner:

![image](https://user-images.githubusercontent.com/1718624/117079071-f7a9c300-ad32-11eb-8950-fd5e754eef8c.png)

Subscriber: 
![image](https://user-images.githubusercontent.com/1718624/117079151-24f67100-ad33-11eb-8087-f3051e2b811d.png)
