### PR TITLE
526 speedup admin dashboard

### DIFF
--- a/migrations/versions/d7b1aaee84ab_add_stripe_status_to_subscription_model.py
+++ b/migrations/versions/d7b1aaee84ab_add_stripe_status_to_subscription_model.py
@@ -1,0 +1,25 @@
+"""add stripe_status to subscription model
+
+Revision ID: d7b1aaee84ab
+Revises: c751fe53a042
+Create Date: 2021-05-01 23:05:25.344813
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "d7b1aaee84ab"
+down_revision = "c751fe53a042"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("subscription") as batch_op:
+        batch_op.add_column(sa.Column("stripe_status", sa.String(), nullable=True))
+
+
+def downgrade():
+    pass

--- a/subscribie/blueprints/admin/__init__.py
+++ b/subscribie/blueprints/admin/__init__.py
@@ -62,6 +62,7 @@ from subscribie.models import (
     TaxRate,
     Category,
 )
+from .subscription import update_stripe_subscription_statuses
 import stripe
 from werkzeug.utils import secure_filename
 
@@ -1038,6 +1039,13 @@ def subscribers():
     return render_template(
         "admin/subscribers.html", people=people.all(), show_active=show_active
     )
+
+
+@admin.route("/refresh-subscription-statuses")
+@login_required
+def refresh_subscriptions():
+    update_stripe_subscription_statuses()
+    return redirect(request.referrer)
 
 
 @admin.route("/archive-subscriber/<subscriber_id>")

--- a/subscribie/blueprints/admin/subscription.py
+++ b/subscribie/blueprints/admin/subscription.py
@@ -1,0 +1,37 @@
+from subscribie.models import Subscription
+from subscribie.database import database
+from subscribie.utils import (
+    get_stripe_secret_key,
+    get_stripe_connect_account,
+    stripe_connect_active,
+)
+import stripe
+import logging
+
+
+def update_stripe_subscription_statuses():
+    """Update Stripe subscriptions with their current status
+    by querying Stripe api"""
+    stripe.api_key = get_stripe_secret_key()
+    connect_account = get_stripe_connect_account()
+    if stripe.api_key is None:
+        logging.error("Stripe api key not set refusing to update subscription statuses")
+    if connect_account is None:
+        logging.error(
+            "Stripe connect account not set. Refusing to update subscription statuses"
+        )
+    if stripe_connect_active():
+        for subscription in Subscription.query.all():
+            try:
+                stripeSubscription = stripe.Subscription.retrieve(
+                    stripe_account=connect_account.id,
+                    id=subscription.stripe_subscription_id,
+                )
+                subscription.stripe_status = stripeSubscription.status
+                database.session.commit()
+            except Exception as e:
+                logging.warning(f"Could not update stripe subscription status: {e}")
+    else:
+        logging(
+            "Refusing to update subscription status since Stripe connect is not active"
+        )

--- a/subscribie/blueprints/admin/templates/admin/subscribers.html
+++ b/subscribie/blueprints/admin/templates/admin/subscribers.html
@@ -23,6 +23,7 @@
           <a href="{{url_for('admin.subscribers', action='show_active')}}" id="show-active-subscribers" class="btn btn-primary">Show Active</a>
       {%endif %}
       <a href="{{url_for('admin.archived_subscribers')}}" class="btn btn-primary">Show Archived</a>
+      <a href="{{url_for('admin.refresh_subscriptions')}}" title="Get latest subscription statuses (active/paused/inactive)" class="btn btn-primary">Refresh Subscriptions</a>
        </div>
       <table class="table mobile-optimised">
         <thead>

--- a/subscribie/blueprints/admin/templates/admin/subscribers.html
+++ b/subscribie/blueprints/admin/templates/admin/subscribers.html
@@ -60,10 +60,6 @@
               {% if person.subscriptions %}
               <ul class="list-unstyled">
                 {% for subscription in person.subscriptions %}
-                    {% if subscription.plan.requirements and subscription.plan.requirements.subscription %}
-                    {# if plan is a subscription, get its live subscription status #}
-                      {% set ns = namespace(stripe_subscription_status = subscription_status(subscription.stripe_subscription_id)) %}
-                    {% endif %}
                     <li>
                         <div class="card">
                             <ul class="list-unstyled px-2">
@@ -102,7 +98,7 @@
                                     </span>
                                     <li><strong>Status: </strong>
                                         {% if subscription.plan.requirements and subscription.plan.requirements.subscription %}
-                                            {{ ns.stripe_subscription_status }}
+                                            {{ subscription.stripe_status }}
                                         {% else %}
                                             Paid
                                         {% endif %}
@@ -121,7 +117,7 @@
                                     </li>
                                     <li><strong>Actions: </strong>
                                         {% if subscription.plan.requirements and subscription.plan.requirements.subscription %}
-                                            {% if ns.stripe_subscription_status == 'Active' %}
+                                            {% if subscription.stripe_status|lower == 'active' %}
                                                 <a href="{{ url_for("admin.pause_stripe_subscription",
                                                 subscription_id=subscription.stripe_subscription_id,
                                                 goback=1) }}">
@@ -133,7 +129,7 @@
                                                     Cancel
                                                 </a> |
                                             {% endif %}
-                                            {% if ns.stripe_subscription_status == 'Paused' %}
+                                            {% if subscription.stripe_status|lower == 'paused' %}
                                                 <a href="{{ url_for("admin.resume_stripe_subscription",
                                                 subscription_id=subscription.stripe_subscription_id,
                                                 goback=1) }}">

--- a/subscribie/models.py
+++ b/subscribie/models.py
@@ -121,6 +121,7 @@ class Subscription(database.Model):
     subscribie_checkout_session_id = database.Column(database.String())
     stripe_subscription_id = database.Column(database.String())
     stripe_external_id = database.Column(database.String())
+    stripe_status = database.Column(database.String())
 
     def stripe_subscription_active(self):
         if self.stripe_subscription_id is not None:

--- a/subscribie/models.py
+++ b/subscribie/models.py
@@ -29,7 +29,11 @@ def filter_archived(query):
         if desc["type"] is Person and "archived-subscribers" in request.path:
             query = query.filter(entity.archived == 1)
             return query
-        elif desc["type"] is Person and "un-archive" not in request.path and "/account/login" not in request.path:
+        elif (
+            desc["type"] is Person
+            and "un-archive" not in request.path
+            and "/account/login" not in request.path
+        ):
             query = query.filter(entity.archived == 0)
             return query
 

--- a/subscribie/models.py
+++ b/subscribie/models.py
@@ -14,12 +14,10 @@ import stripe
 from subscribie.utils import (
     get_stripe_secret_key,
     get_stripe_connect_account_id,
-    get_stripe_connect_account,
 )
 from flask import request
 
 from .database import database
-import logging
 
 
 @event.listens_for(Query, "before_compile", retval=True, bake_ok=True)
@@ -129,21 +127,8 @@ class Subscription(database.Model):
 
     def stripe_subscription_active(self):
         if self.stripe_subscription_id is not None:
-
-            stripe.api_key = get_stripe_secret_key()
-            connect_account = get_stripe_connect_account()
-            try:
-                subscription = stripe.Subscription.retrieve(
-                    stripe_account=connect_account.id, id=self.stripe_subscription_id
-                )
-                if subscription.pause_collection is not None:
-                    return False
-                elif subscription.status == "active":
-                    return True
-            except stripe.error.InvalidRequestError as e:
-                logging.error("Could not get stripe subscription status")
-                logging.error(e)
-
+            if self.stripe_status == "active":
+                return True
         return False
 
     def upcoming_invoice(self):

--- a/subscribie/utils.py
+++ b/subscribie/utils.py
@@ -1,6 +1,7 @@
 from flask import current_app, request, g
 import stripe
 from subscribie import database
+import logging
 
 
 def get_stripe_secret_key():
@@ -79,6 +80,21 @@ def get_stripe_connect_account_id():
         account_id = payment_provider.stripe_test_connect_account_id
 
     return account_id
+
+
+def stripe_connect_active():
+    stripe.api_key = get_stripe_secret_key()
+    connect_account_id = get_stripe_connect_account_id()
+    if stripe.api_key is None or stripe.api_key == "":
+        return False
+    if connect_account_id is None:
+        return False
+    try:
+        stripe.Balance.retrieve(stripe_account=connect_account_id)
+        return True
+    except Exception as e:
+        logging.info(e)
+        return False
 
 
 def format_to_stripe_interval(plan: str):


### PR DESCRIPTION
Fix #526 

- Dashboard & View Subscribers page now loads 'instantly'
- Added 'stripe_status' database column to 'subscription' table
- Remove stripe api calls per subscriber
- Added route for shop owner to refresh subscriptions
- TODO in other issue: Add refresh to uwsgi cron or similar