### PR TITLE
Fix #545 subscriber login from welcome email

### DIFF
--- a/migrations/versions/c48dccfb0df5_add_password_expired_to_user_and_.py
+++ b/migrations/versions/c48dccfb0df5_add_password_expired_to_user_and_.py
@@ -1,0 +1,28 @@
+"""add password_expired to user and subscriber models
+
+Revision ID: c48dccfb0df5
+Revises: 2378e3286d5b
+Create Date: 2021-05-22 14:07:47.465185
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "c48dccfb0df5"
+down_revision = "2378e3286d5b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("person") as batch_op:
+        batch_op.add_column(sa.Column("password_expired", sa.Boolean(), nullable=True))
+
+    with op.batch_alter_table("user") as batch_op:
+        batch_op.add_column(sa.Column("password_expired", sa.Boolean(), nullable=True))
+
+
+def downgrade():
+    pass

--- a/subscribie/blueprints/checkout/__init__.py
+++ b/subscribie/blueprints/checkout/__init__.py
@@ -123,6 +123,7 @@ def store_customer():
                 email=email,
                 mobile=mobile,
                 password=str(os.urandom(16)),
+                password_expired=1,
             )
             database.session.add(person)
             database.session.commit()

--- a/subscribie/blueprints/subscriber/templates/subscriber/login.html
+++ b/subscribie/blueprints/subscriber/templates/subscriber/login.html
@@ -12,7 +12,7 @@
         <p>Pop your email address that you signed up with in the box below and we'll send you an email, click the link in that email and you'll be securely logged in.</p>
         <form method="POST" action="{{ url_for('auth.login') }}">
           {{ form.csrf_token }}
-          <input id="email" class="form-control form-control-lg mt-4" name="email" type="email" placeholder="Email Address" value="">
+          <input id="email" class="form-control form-control-lg mt-4" name="email" type="email" placeholder="Email Address" value="{{ request.args.get("email") or '' }}">
           <button type="submit" class="btn btn-success btn-lg btn-block my-3">
             <span style="margin-right:1rem" class="icon"><i class="fas fa-magic"></i></span><span>Magic Login</span>
           </button>
@@ -25,7 +25,7 @@
       <div class="card-body">
         <form method="POST" action="{{ url_for('subscriber.login') }}">
           {{ form.csrf_token }}
-          <input id="email" class="form-control form-control-lg mt-4" name="email" type="email" placeholder="Email Address" required>
+          <input id="email" class="form-control form-control-lg mt-4" name="email" type="email" placeholder="Email Address" value="{{ request.args.get("email") or '' }}" required>
           <input id="password" class="form-control form-control-lg mt-4" name="password" type="password" placeholder="Password" required>
           
           <button type="submit" class="btn btn-success btn-lg btn-block my-3">

--- a/subscribie/email.py
+++ b/subscribie/email.py
@@ -56,6 +56,7 @@ def send_welcome_email():
         first_charge_date=first_charge_date,
         first_charge_amount=first_charge_amount,
         plan=plan,
+        subscriber_email=session.get("email"),
     )
 
     try:

--- a/subscribie/emails/welcome.jinja2.html
+++ b/subscribie/emails/welcome.jinja2.html
@@ -20,7 +20,7 @@
 
 
 <p>You can login to manage your account at:
-    <a href="{{ subscriber_login_url }}">My account</a>
+    <a href="{{ subscriber_login_url }}?email={{ subscriber_email }}">My account</a>
 </p>
 
 <p>Once again welcome to {{ company_name }}.</p>

--- a/subscribie/models.py
+++ b/subscribie/models.py
@@ -29,8 +29,13 @@ def filter_archived(query):
             return query
         elif (
             desc["type"] is Person
+            and request.path != "/"
             and "un-archive" not in request.path
             and "/account/login" not in request.path
+            and "/auth/login" not in request.path
+            and "/account/forgot-password" not in request.path
+            and "account/password-reset" not in request.path
+            and "/account" not in request.path
         ):
             query = query.filter(entity.archived == 0)
             return query
@@ -55,6 +60,7 @@ class User(database.Model):
     active = database.Column(database.String)
     login_token = database.Column(database.String)
     password_reset_string = database.Column(database.String())
+    password_expired = database.Column(database.Boolean(), default=0)
 
     def set_password(self, password):
         self.password = generate_password_hash(password)
@@ -81,6 +87,7 @@ class Person(database.Model, HasArchived):
     email = database.Column(database.String())
     password = database.Column(database.String())  # Hash of password
     password_reset_string = database.Column(database.String())
+    password_expired = database.Column(database.Boolean(), default=1)
     mobile = database.Column(database.String())
     subscriptions = relationship("Subscription", back_populates="person")
     transactions = relationship("Transaction", back_populates="person")


### PR DESCRIPTION
Ref #545 

When a subscriber gets their welcome email, and they click "My Account"
If their password isn't set, then they *automatically* get a password reset email, and a notification on screen 
informing the subscriber that they should check their email to set the password. 

# 1. Welcome email

Hello Anne Davis,

```
Welcome to Soap Subscription
Plan name: Bath Soaps
Interval: monthly
Amount: £10.99
Each payment will be on the same day monthly
You can login to manage your account at: <a href="link to login?email=fred@example.com">My account</a>
Once again welcome to Soap Subscription 
```

# 2. Subscriber visits 'My Account'

![image](https://user-images.githubusercontent.com/1718624/119229517-51bace80-bb10-11eb-8346-4de378ff2fde.png)

# 3. Follows automatic reset password email link
![image](https://user-images.githubusercontent.com/1718624/119229594-a8280d00-bb10-11eb-8241-f26409553ac0.png)


#4. Subscriber sets their password

![image](https://user-images.githubusercontent.com/1718624/119229625-d4438e00-bb10-11eb-8fba-71a50f869c9a.png)

#5. subscriber may login

![image](https://user-images.githubusercontent.com/1718624/119229660-f9d09780-bb10-11eb-8c0f-c02044077c7a.png)

