### PR TITLE
Fix #565 load upcoming payments instantly, provide refresh mechanism

### DIFF
--- a/migrations/versions/3a8f3089d09d_create_upcoming_invoice_table.py
+++ b/migrations/versions/3a8f3089d09d_create_upcoming_invoice_table.py
@@ -1,0 +1,40 @@
+"""create upcoming invoice table
+
+Revision ID: 3a8f3089d09d
+Revises: c48dccfb0df5
+Create Date: 2021-05-31 21:24:34.681376
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "3a8f3089d09d"
+down_revision = "c48dccfb0df5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "upcoming_invoice",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("stripe_subscription_id", sa.String(), nullable=True),
+        sa.Column("stripe_invoice_status", sa.String(), nullable=True),
+        sa.Column("stripe_amount_due", sa.String(), nullable=True),
+        sa.Column("stripe_amount_paid", sa.String(), nullable=True),
+        sa.Column("stripe_currency", sa.String(), nullable=True),
+        sa.Column("stripe_next_payment_attempt", sa.String(), nullable=True),
+        sa.Column("subscription_uuid", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["subscription_uuid"],
+            ["subscription.uuid"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade():
+    pass

--- a/subscribie/__init__.py
+++ b/subscribie/__init__.py
@@ -47,8 +47,6 @@ from .models import (
     Module,
 )
 
-from .blueprints.admin import get_subscription_status
-
 log = logging.getLogger(__name__)
 
 
@@ -219,10 +217,7 @@ def create_app(test_config=None):
 
         for person in people:
             for subscription in person.subscriptions:
-                if (
-                    get_subscription_status(subscription.gocardless_subscription_id)
-                    == "active"
-                ):
+                if subscription.stripe_status == "active":
                     # Check if x days until next subscription due, make configurable
                     today = datetime.date.today()
                     days_until = subscription.next_date().date() - today

--- a/subscribie/blueprints/admin/invoice.py
+++ b/subscribie/blueprints/admin/invoice.py
@@ -1,0 +1,56 @@
+import logging
+from subscribie.database import database
+from subscribie.models import UpcomingInvoice, Subscription
+from subscribie.utils import (
+    get_stripe_secret_key,
+    get_stripe_connect_account,
+)
+import stripe
+
+log = logging.getLogger(__name__)
+
+
+def fetch_stripe_upcoming_invoices():
+    """Fetch all Stripe upcoming invoices and populate the invoices table"""
+    all_subscriptions = Subscription.query.all()
+    upcoming_invoices = []
+    stripe.api_key = get_stripe_secret_key()
+    connect_account = get_stripe_connect_account()
+
+    # Prepare to delete all previous upcomingInvoice
+    UpcomingInvoice.query.delete()  # don't commit until finished fetching latest collection # noqa
+    for subscription in all_subscriptions:
+        try:
+            log.info(
+                f"Getting upcoming invoice for Stripe subscription: {subscription.stripe_subscription_id}"  # noqa
+            )
+            if subscription.stripe_subscription_id is not None:
+                upcoming_invoice = stripe.Invoice.upcoming(
+                    subscription=subscription.stripe_subscription_id,
+                    stripe_account=connect_account.id,
+                )
+                upcoming_invoices.append(upcoming_invoice)
+                # Store the UpcomingInvoice
+                upcomingInvoice = UpcomingInvoice()
+                upcomingInvoice.subscription = subscription
+                upcomingInvoice.stripe_invoice_id = None
+                upcomingInvoice.stripe_subscription_id = (
+                    subscription.stripe_subscription_id
+                )
+                upcomingInvoice.stripe_invoice_status = upcoming_invoice.status
+                upcomingInvoice.stripe_amount_due = upcoming_invoice.amount_due
+                upcomingInvoice.stripe_amount_paid = upcoming_invoice.amount_paid
+                upcomingInvoice.stripe_next_payment_attempt = (
+                    upcoming_invoice.next_payment_attempt
+                )
+                upcomingInvoice.stripe_currency = upcoming_invoice.currency
+
+                database.session.add(upcomingInvoice)
+
+        except stripe.error.InvalidRequestError as e:
+            log.error(
+                f"Cannot get stripe subscription id: {subscription.stripe_subscription_id}, {e}"  # noqa
+            )
+        except Exception as e:
+            log.error(f"Error checking for upcoming invoice for {subscription.id}, {e}")
+        database.session.commit()

--- a/subscribie/blueprints/admin/templates/admin/upcoming_invoices.html
+++ b/subscribie/blueprints/admin/templates/admin/upcoming_invoices.html
@@ -22,23 +22,24 @@ li { list-style: none}
       <p>
       Subscriptions which have upcoming invoices.
       </p>
+      <p>
+      Note that when you are viewing an upcoming invoice, you are simply viewing a preview – the invoice has not yet been created.
+      </p>
+      <button id="fetch_upcoming_invoices" title="Get latest upcoming invoices" class="btn btn-primary disable-on-click">Fetch Upcoming Invoices</button>
       <table class="table table-hover table-scroll">
   
         <thead>
           <tr>
-            <th>Fulfillment State</th>
-            <th>Due Date</th>
             <th>Status</th>
-            <th>Amount</th>
-            <th>Name</th>
-            <th>Contacts</th>
-            <th>Address</th>
+            <th>Person</th>
+            <th>Due Date</th>
+            <th>Amount Due</th>
             <th>Subscription</th>
           </tr>
         </thead>
   
         <tbody>
-        {% if subscriptions|length == 0 %}
+        {% if upcomingInvoices|length == 0 %}
           <tr>
             <td colspan="9">
                No upcoming invoices yet. You can do it!
@@ -46,96 +47,72 @@ li { list-style: none}
           </td>
         {% endif %}
   
-        {% for subscription in subscriptions %}
-        {% set upcoming_invoice = subscription.upcoming_invoice() %}
+        {% for upcomingInvoice in upcomingInvoices %}
+          {% if upcomingInvoice.subscription.person %}
           <tr>
+            <td title="Valid states are: Draft, Deleted, Open, Paid, Uncollectible, Void">{{ upcomingInvoice.stripe_invoice_status }}</td>
             <td>
-              <form action="{{ url_for('admin.update_payment_fulfillment', stripe_external_id=upcoming_invoice.subscription) }}" method="GET">
-                <select class="form-control form-control-sm my-2" name="state">
-                  {% set fulfillment_state = get_transaction_fulfillment_state(upcoming_invoice.subscription) %}
-                  <option value="">-</option>
-                  <option value="complete"
-                    {% if fulfillment_state == "complete" %}
-                    selected
-                    {% endif %}>
-                    Complete
-                  </option>
-                </select>
-                <input type="submit" class="btn btn-primary btn-sm btn-block" value="Update" />
-              </form>
-            </td>
-            <td>{{ datetime.fromtimestamp(upcoming_invoice.next_payment_attempt).strftime("%d/%m/%Y") }}</td>
-            <td title="Valid states are: Draft, Deleted, Open, Paid, Uncollectible, Void">{{ upcoming_invoice.status }}</td>
-            <td class="upcoming-invoice-amount">{{ upcoming_invoice.amount_due|default(0)|currencyFormat }}</td>
-            {% if subscription.upcoming_invoice()  %}
-            <td>
-              <a href="{{ url_for('admin.show_subscriber', subscriber_id=subscription.person.id) }}">
-                {{ subscription.person.given_name }} {{ subscription.person.family_name }}
+              <a href="{{ url_for('admin.show_subscriber', subscriber_id=upcomingInvoice.subscription.person.id) }}">
+                {{ upcomingInvoice.subscription.person.given_name }} {{ upcomingInvoice.subscription.person.family_name }}
               </a>
             </td>
-            <td>
-              <strong>Email: </strong><a href="mailto:{{ subscription.person.email }}">{{ subscription.person.email }}</a><br>
-              <strong>Phone: </strong><a href="tel:{{ subscription.person.mobile}}">{{ subscription.person.mobile}}</a><br>
-            </td>
-            <td><address>
-                {{ subscription.person.address_line1 }}<br />
-                {{ subscription.person.city }}
-                {{ subscription.person.postal_code }}
-            </address></td>
+
+            <td>{{ upcomingInvoice.stripe_next_payment_attempt | timestampToDate }}</td>
+            <td class="upcoming-invoice-amount">{{ upcomingInvoice.stripe_amount_due|default(0)|currencyFormat }}</td>
             <td>
               <div class="content">
                 <ul class="is-unstyled-li">
                   <li>
                     <div class="card">
                       <ul class="list-unstyled px-2">
-                        <li><strong>Plan: </strong>{{ subscription.plan.title }}</li>
-                        {% if subscription.chosen_options %}
+                        <li><strong>Plan: </strong>{{ upcomingInvoice.subscription.plan.title }}</li>
+                        {% if upcomingInvoice.subscription.chosen_options %}
                         <li>
                             <details open>
                               <summary><strong>Chosen Options</strong></summary>
                               <ul>
-                              {% for choice in subscription.chosen_options %}
+                              {% for choice in upcomingInvoice.subscription.chosen_options %}
                                 <li><strong>{{ choice.choice_group_title }}:</strong> {{ choice.option_title }}</li>
                               {% endfor %}
                               </ul>
                             </details>
                         </li>
                         {% endif %}
-                        <li><strong>Date started: </strong>{{ subscription.created_at.strftime('%Y-%m-%d') }}</li>
+                        <li><strong>Date started: </strong>{{ upcomingInvoice.subscription.created_at.strftime('%Y-%m-%d') }}</li>
                         <li>
-                            {% if subscription.plan.requirements.subscription %}
-                              <strong>Price ({{ subscription.plan.interval_unit }}): </strong>
-                              <span class="plan-price-interval">{{ subscription.plan.interval_amount |default(0)|currencyFormat }}</span>
+                            {% if upcomingInvoice.subscription.plan.requirements.subscription %}
+                              <strong>Price ({{ upcomingInvoice.subscription.plan.interval_unit }}): </strong>
+                              <span class="plan-price-interval">{{ upcomingInvoice.subscription.plan.interval_amount |default(0)|currencyFormat }}</span>
                             {% else %}
                               (One-off. Not a subscription)
                             {% endif %}
                         </li>
                         <li><strong>Sell price: </strong>
-                            {% if subscription.plan.requirements.instant_payment %}
-                            <span class="plan-sell-price">{{ subscription.plan.sell_price|default(0)|currencyFormat }}</span>
+                            {% if upcomingInvoice.subscription.plan.requirements.instant_payment %}
+                            <span class="plan-sell-price">{{ upcomingInvoice.subscription.plan.sell_price|default(0)|currencyFormat }}</span>
                             {% else %}
                               <span class="upcoming-invoices-plan-no-sell_price">(No up-front cost)</span>
                             {% endif %}
                         </li>
                         <li><strong>Status: </strong>
-                            {% if subscription.plan.requirements.subscription %}
-                                {{subscription_status(subscription.stripe_external_id)}}
+                            {% if upcomingInvoice.subscription.plan.requirements.subscription %}
+                                {{ upcomingInvoice.subscription.stripe_status }}
                             {% else %}
                                 Paid
                             {% endif %}
                         </li>
                         <li><strong>Actions: </strong>
-                          {% if subscription.stripe_external_id %}
-                            {% if subscription_status(subscription.stripe_external_id) == 'Active' %}
+                          {% if upcomingInvoice.subscription.stripe_subscription_id%}
+                            {% if upcomingInvoice.subscription.stripe_status == 'active' %}
                             <a href="{{ url_for("admin.pause_stripe_subscription",
-                              subscription_id=subscription.stripe_external_id,
+                              subscription_id=upcomingInvoice.subscription.stripe_subscription_id,
                               goback=1) }}">
                             Pause
                             </a> | 
                             {% endif %}
-                            {% if subscription_status(subscription.stripe_external_id) == 'Paused' %}
+                            {% if upcomingInvoice.subscription.stripe_status == 'paused' %}
                             <a href="{{ url_for("admin.resume_stripe_subscription",
-                              subscription_id=subscription.stripe_external_id,
+                              subscription_id=upcomingInvoice.subscription.stripe_subscription_id,
                               goback=1) }}">
                             Resume
                             </a>
@@ -147,29 +124,32 @@ li { list-style: none}
                 </ul>
               </div>
             </td>
-            {% else %}
-            <td colspan="4"></td>
-            {% endif %}
           </tr>
+          {% endif %}
         {% endfor %}
         </tbody>
         
       </table>
 
-      <nav role="navigation" aria-label="pagination">
-        <ul class="pagination justify-content-start">
-          <li class="page-item">
-              <a class="page-link" href="{{ url_for('admin.upcoming_invoices', previous=previous_page_cursor) }}">Previous</a>
-          </li>
-          <li class="page-item">
-              <a class="page-link" href="{{ url_for('admin.upcoming_invoices', next=next_page_cursor) }}">Next page</a>
-          </li>
-        </ul>
-      </nav>
-
     </div><!-- end .container -->
   </div><!-- end .section -->
 </main>
+
+<script>
+
+{# Fetch upcoming invoices when button clicked #}
+btnFetchUpcomingInvoices = document.getElementById('fetch_upcoming_invoices');
+
+btnFetchUpcomingInvoices.addEventListener('click', fetchUpcomingInvoices);
+
+function fetchUpcomingInvoices(e) {
+  e.target.textContent = 'Refreshing Upcoming Payments';
+  fetch("{{ url_for('admin.fetch_upcoming_invoices') }}")
+  .then(response => { document.location = "{{ url_for('admin.upcoming_invoices') }}" });
+}
+{# End fetch upcoming invoices when button clicked #}
+
+</script>
 
 
 

--- a/subscribie/models.py
+++ b/subscribie/models.py
@@ -11,11 +11,6 @@ from datetime import datetime
 from uuid import uuid4
 from werkzeug.security import generate_password_hash, check_password_hash
 from dateutil.relativedelta import relativedelta
-import stripe
-from subscribie.utils import (
-    get_stripe_secret_key,
-    get_stripe_connect_account_id,
-)
 from flask import request
 
 from .database import database
@@ -124,6 +119,9 @@ class Subscription(database.Model):
         primaryjoin="foreign(Plan.uuid)==Subscription.sku_uuid",  # noqa
     )
     person = relationship("Person", back_populates="subscriptions")
+    upcoming_invoice = relationship(
+        "UpcomingInvoice", back_populates="subscription", uselist=False
+    )
     note = relationship(
         "SubscriptionNote", back_populates="subscription", uselist=False
     )
@@ -145,24 +143,6 @@ class Subscription(database.Model):
             if self.stripe_status == "active":
                 return True
         return False
-
-    def upcoming_invoice(self):
-        """Return the upcoming invoice (if exists) associated with this Subscription"""
-        stripe.api_key = get_stripe_secret_key()
-        stripe_connect_account_id = get_stripe_connect_account_id()
-
-        if self.stripe_subscription_id is not None:
-            try:
-                upcoming_invoice = stripe.Invoice.upcoming(
-                    subscription=self.stripe_subscription_id,
-                    stripe_account=stripe_connect_account_id,
-                )
-                return upcoming_invoice
-            except stripe.error.InvalidRequestError as e:
-                log.error(
-                    f"Cannot get stripe subscription id: {self.stripe_subscription_id}. {e}"  # noqa: E501
-                )
-        return None
 
     def next_date(self):
         """Return the next delivery date of this subscription
@@ -212,6 +192,34 @@ class SubscriptionNote(database.Model):
         database.Integer(), ForeignKey("subscription.id")
     )  # noqa
     subscription = relationship("Subscription", back_populates="note")
+
+
+class UpcomingInvoice(database.Model):
+    """
+    A temporary view of upcoming invoices.
+
+    The keys in this table must not be relied upon.
+    Entries in this table are *removed* and fetched again by
+    subscribie.invoice.fetch_stripe_upcoming_invoices
+
+    Requires syncing with stripe api as invoices transition
+    to paid (or failed).
+    """
+
+    __tablename__ = "upcoming_invoice"
+    id = database.Column(database.Integer(), primary_key=True)
+    created_at = database.Column(database.DateTime, default=datetime.utcnow)
+    # Note, upcoming invoices do not have an id https://stripe.com/docs/api/invoices/upcoming # noqa
+    stripe_subscription_id = database.Column(database.String())
+    stripe_invoice_status = database.Column(database.String())
+    stripe_amount_due = database.Column(database.String())
+    stripe_amount_paid = database.Column(database.String())
+    stripe_currency = database.Column(database.String())
+    stripe_next_payment_attempt = database.Column(database.String())
+    subscription_uuid = database.Column(
+        database.Integer, ForeignKey("subscription.uuid")
+    )
+    subscription = relationship("Subscription", back_populates="upcoming_invoice")
 
 
 class Company(database.Model):


### PR DESCRIPTION
Ref #565 

TODO add call to cron to auto refresh upcoming invoices by calling https://github.com/Subscribie/subscribie/blob/565-upcomming-payments-faster/subscribie/blueprints/admin/__init__.py#L1046 via cron
TODO update playwright tests