### PR TITLE
769 shop owner can activate their own shop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@
 # Change FLASK_ENV=live for live
 FLASK_ENV=development
 
+SAAS_URL=https://subscribie.co.uk/
+SAAS_ACTIVATE_ACCOUNT_PATH=/activate
+
 # For testing this repo in isolation, SUBSCRIBIE_REPO_DIRECTORY can be './'
 # for production, SUBSCRIBIE_REPO_DIRECTORY should be wherever the repo
 # is cloned to

--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,11 @@
 # Change FLASK_ENV=live for live
 FLASK_ENV=development
 
+# Software as a service (SAAS)
 SAAS_URL=https://subscribie.co.uk/
+# SAAS_API_KEY is to allow subscribie platform to send authenticated
+# api requests to subscribie shops created by the shop builder.
+SAAS_API_KEY=changeme
 SAAS_ACTIVATE_ACCOUNT_PATH=/activate
 
 # For testing this repo in isolation, SUBSCRIBIE_REPO_DIRECTORY can be './'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# v0.1.7 (Thu Jan 13 2022)
+
+#### 🐛 Bug Fix
+
+- Merge branch '752-update-wtf-forms' [#753](https://github.com/Subscribie/subscribie/pull/753) ([@chrisjsimpson](https://github.com/chrisjsimpson))
+
+#### Authors: 1
+
+- [@chrisjsimpson](https://github.com/chrisjsimpson)
+
+---
+
 # v0.1.6 (Tue Jan 11 2022)
 
 #### 🐛 Bug Fix

--- a/migrations/versions/dde6bed9a56f_add_shop_activated_to_setting_model.py
+++ b/migrations/versions/dde6bed9a56f_add_shop_activated_to_setting_model.py
@@ -1,0 +1,25 @@
+"""add shop_activated to setting model
+
+Revision ID: dde6bed9a56f
+Revises: 96430096c2c7
+Create Date: 2022-01-25 10:04:41.225725
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'dde6bed9a56f'
+down_revision = '96430096c2c7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("setting") as batch_op:
+        batch_op.add_column(sa.Column('shop_activated', sa.Boolean(), default=0))
+
+
+def downgrade():
+    pass

--- a/subscribie/blueprints/admin/__init__.py
+++ b/subscribie/blueprints/admin/__init__.py
@@ -804,6 +804,12 @@ def set_stripe_livemode():
 @admin.route("/connect/stripe-connect", methods=["GET"])
 @login_required
 def stripe_connect():
+    setting = Setting.query.first()
+    shop_activated = setting.shop_activated
+    SERVER_NAME = os.getenv("SERVER_NAME")
+    saas_url = current_app.config.get('SAAS_URL')
+    saas_activate_account_path = current_app.config.get('SAAS_ACTIVATE_ACCOUNT_PATH')
+    saas_activate_account_url = saas_url + saas_activate_account_path + f'/{SERVER_NAME}'  # noqa: E501
     account = None
     stripe_express_dashboard_url = None
     stripe.api_key = get_stripe_secret_key()
@@ -838,7 +844,6 @@ def stripe_connect():
             ).url
         except stripe.error.InvalidRequestError:
             stripe_express_dashboard_url = None
-
     database.session.commit()
     return render_template(
         "admin/settings/stripe/stripe_connect.html",
@@ -846,6 +851,8 @@ def stripe_connect():
         account=account,
         payment_provider=payment_provider,
         stripe_express_dashboard_url=stripe_express_dashboard_url,
+        shop_activated=shop_activated,
+        saas_activate_account_url=saas_activate_account_url
     )
 
 

--- a/subscribie/blueprints/admin/templates/admin/settings/stripe/stripe_connect.html
+++ b/subscribie/blueprints/admin/templates/admin/settings/stripe/stripe_connect.html
@@ -36,7 +36,8 @@
             {% endif %}
             </button>
 
-          {% else %}
+          {% elif account.payouts_enabled is sameas False %}
+            {# Only require non-already stripe connected sites to activate via human operator #}
             <a href="{{ saas_activate_account_url }}" class="btn btn-success">Start taking live payments</a>
           {% endif %}
 

--- a/subscribie/blueprints/admin/templates/admin/settings/stripe/stripe_connect.html
+++ b/subscribie/blueprints/admin/templates/admin/settings/stripe/stripe_connect.html
@@ -36,7 +36,7 @@
             {% endif %}
             </button>
 
-          {% elif account.payouts_enabled is sameas False %}
+          {% elif account.payouts_enabled is not sameas True %}
             {# Only require non-already stripe connected sites to activate via human operator #}
             <a href="{{ saas_activate_account_url }}" class="btn btn-success">Start taking live payments</a>
           {% endif %}

--- a/subscribie/blueprints/admin/templates/admin/settings/stripe/stripe_connect.html
+++ b/subscribie/blueprints/admin/templates/admin/settings/stripe/stripe_connect.html
@@ -23,15 +23,22 @@
           <p>Connect to Stripe below. When your subscribers pay one-off amounts, they 
           will be paid out to your into your bank account via Stripe.
           </p>
+          {# Only allow activated shops to activate Stripe
+             in live mode #}
+          {% if shop_activated %}
 
-          <button id="submit" class="btn btn-success">
-          Setup payouts on Stripe
-          {% if payment_provider.stripe_livemode %}
-            (live mode)
+            <button id="submit" class="btn btn-success">
+            Setup payouts on Stripe
+            {% if payment_provider.stripe_livemode %}
+              (live mode)
+            {% else %}
+              (test mode)
+            {% endif %}
+            </button>
+
           {% else %}
-            (test mode)
+            <a href="{{ saas_activate_account_url }}" class="btn btn-success">Start taking live payments</a>
           {% endif %}
-          </button>
 
 
           {% if account.payouts_enabled is sameas False and payment_provider.stripe_livemode is sameas True %}

--- a/subscribie/blueprints/api/__init__.py
+++ b/subscribie/blueprints/api/__init__.py
@@ -1,6 +1,8 @@
 import logging
 from flask import Blueprint, url_for, jsonify
-from subscribie.models import Page
+from subscribie.models import Page, Setting
+from subscribie.database import database
+from subscribie.auth import saas_api_only
 
 log = logging.getLogger(__name__)
 
@@ -20,3 +22,21 @@ def apiv1_list_pages():
             }
         )
     return jsonify(urls)
+
+
+@apiv1.route("/activate-shop", methods=["GET"])
+@saas_api_only
+def apiv1_activate_shop():
+    setting = Setting.query.first()
+    setting.shop_activated = 1
+    database.session.commit()
+    return jsonify({"msg": "shop activated"})
+
+
+@apiv1.route("/deactivate-shop", methods=["GET"])
+@saas_api_only
+def apiv1_deativate_account():
+    setting = Setting.query.first()
+    setting.shop_activated = 0
+    database.session.commit()
+    return jsonify({"msg": "shop deactivated"})

--- a/subscribie/blueprints/checkout/__init__.py
+++ b/subscribie/blueprints/checkout/__init__.py
@@ -206,11 +206,21 @@ def thankyou():
             f"{scheme}://{sitename}/api/v1/activate-shop?SAAS_API_KEY={SAAS_API_KEY}"
         )
         # Activate the shop by calling the activate shop api request
-        req = requests.get(activate_shop_url, timeout=1)
-        log.info(f"Activating shop {sitename}")
-        log.info(f"Result of activating shop status_code: {req.status_code}")
-        if req.status_code != 200:
-            log.error(f"Unable to activate shop {sitename}.")
+        try:
+            req = requests.get(activate_shop_url, timeout=1)
+            log.info(f"Activating shop {sitename}")
+            if req.status_code == 200:
+                log.info(f"Succedd activating shop. status_code: {req.status_code}")
+            # Set site url for login button on thank you page
+            session["site-url"] = f"{scheme}://{sitename}"
+            # Remove sitename from session as no longer needed
+            session.pop("sitename")
+        except requests.exceptions.ConnectionError as e:
+            log.error(f"Unable to activate shop {sitename}. Could not make api request to activate: {e}.")  # noqa: E501
+        except requests.HTTPError as e:
+            log.error(f"Unable to activate shop {sitename}. HTTPError: {e}.")  # noqa: E501
+        except Exception as e:
+            log.error(f"Unable to activate shop {sitename}. Unhandled reason: {e}.")  # noqa: E501
 
     # Remove subscribie_checkout_session_id from session
     checkout_session_id = session.pop("subscribie_checkout_session_id", None)

--- a/subscribie/blueprints/checkout/__init__.py
+++ b/subscribie/blueprints/checkout/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import requests
 from flask import (
     Blueprint,
     render_template,
@@ -191,6 +192,26 @@ def thankyou():
     if session.get("plan") is None:
         log.warn("Visit to /thankyou with no plan in session")
         return redirect("/")
+
+    # Activate shop if session["sitename"] present
+    if session.get("sitename"):
+        # Build activation api request
+        sitename = session.get("sitename")
+        SAAS_API_KEY = current_app.config.get("SAAS_API_KEY")
+        if "127.0.0.1" in request.remote_addr and not request.is_secure:
+            scheme = "http"  # allow local development
+        else:
+            scheme = "https"
+        activate_shop_url = (
+            f"{scheme}://{sitename}/api/v1/activate-shop?SAAS_API_KEY={SAAS_API_KEY}"
+        )
+        # Activate the shop by calling the activate shop api request
+        req = requests.get(activate_shop_url, timeout=1)
+        log.info(f"Activating shop {sitename}")
+        log.info(f"Result of activating shop status_code: {req.status_code}")
+        if req.status_code != 200:
+            log.error(f"Unable to activate shop {sitename}.")
+
     # Remove subscribie_checkout_session_id from session
     checkout_session_id = session.pop("subscribie_checkout_session_id", None)
     subscription = (

--- a/subscribie/models.py
+++ b/subscribie/models.py
@@ -528,6 +528,7 @@ class Setting(database.Model):
     reply_to_email_address = database.Column(database.String())
     charge_vat = database.Column(database.Boolean(), default=False)
     custom_code = database.Column(database.String(), default=None)
+    shop_activated = database.Column(database.Boolean(), default=False)
 
 
 class File(database.Model):


### PR DESCRIPTION
Ref #769

Steps to test (locally)

- Set .env.example settings, for `SAAS_URL` but your localhost development machine e.g. `http://127.0.0.1:5000` (note that your `.env` file must have the builder module installed (path) and theme `builder` active.

- Login to shop
- Go to payment gateways -> Connect stripe
- Click 'Start taking live payments'
- You will get directed to choose and pay for a plan
- After sign-up, you will be able to log back into your shop (TODO auto redirect them back!)
- Go to payment gateways -> Connect stripe
- Observe that  'Start taking live payments' is no longer an option (because the shop is now activated)


