### PR TITLE
Fix #808 bump flask to version 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,11 @@
 wheel
-Werkzeug==1.0.1
-Flask>=1,<2
+Flask>=2,<3
 flask_cors
 Flask-Reuploaded==0.3.2
 Flask-WTF==1.0.0
 email-validator==1.1.3
 Flask-Mail>=0.9.1
-requests==2.25.0
+requests==2.27.1
 blinker==1.4
 stripe
 GitPython


### PR DESCRIPTION

- Fix #808 bump flask to version 2
- remove Werkzeug because is included as dependency of flask
- bump requests to 2.27.1