### PR TITLE
Fix #845 introduce background_task decorator

### DIFF
--- a/subscribie/blueprints/admin/__init__.py
+++ b/subscribie/blueprints/admin/__init__.py
@@ -1046,7 +1046,7 @@ def refresh_subscriptions():
         flash(
             "Note: Subscription statuses are refreshed automatically every 10 minutes so you don't need to keep clicking refresh."  # noqa
         )
-        return redirect(request.referrer)
+        return redirect(url_for("admin.subscribers"))
     return "Refresh Subscription statuses requested", 202
 
 

--- a/subscribie/blueprints/admin/__init__.py
+++ b/subscribie/blueprints/admin/__init__.py
@@ -1038,14 +1038,16 @@ def subscribers():
 
 @admin.route("/refresh-subscription-statuses")
 def refresh_subscriptions():
+
     update_stripe_subscription_statuses()
+
     if request.referrer is not None:
-        flash("subscription statuses have been refreshed.")
+        flash("We've started refreshing all subscription statuses for you right away.")
         flash(
-            "note: this is done automatically every 10 minutes so you don't need to keep clicking refresh."  # noqa
+            "Note: Subscription statuses are refreshed automatically every 10 minutes so you don't need to keep clicking refresh."  # noqa
         )
         return redirect(request.referrer)
-    return "Subscription statuses refreshed", 200
+    return "Refresh Subscription statuses requested", 202
 
 
 @admin.route("/refresh-invoices")

--- a/subscribie/blueprints/admin/subscription.py
+++ b/subscribie/blueprints/admin/subscription.py
@@ -5,55 +5,64 @@ from subscribie.utils import (
     get_stripe_connect_account,
     stripe_connect_active,
 )
+from subscribie.tasks import background_task
 import stripe
 import logging
+
 
 log = logging.getLogger(__name__)
 
 
-def update_stripe_subscription_statuses():
+@background_task
+def update_stripe_subscription_statuses(app):
     """Update Stripe subscriptions with their current status
-    by querying Stripe api"""
-    stripe.api_key = get_stripe_secret_key()
-    connect_account = get_stripe_connect_account()
-    if stripe.api_key is None:
-        log.error("Stripe api key not set refusing to update subscription statuses")
-    if connect_account is None:
-        log.error(
-            "Stripe connect account not set. Refusing to update subscription statuses"
-        )
-    if stripe_connect_active():
-        try:
-            # See https://stripe.com/docs/api/subscriptions/list#list_subscriptions-status # noqa: E501
-            stripeSubscriptions = stripe.Subscription.list(
-                stripe_account=connect_account.id, status="all", limit=100
+    by querying Stripe api
+
+    :param: app (required) note app is automatically injected by @background_task decorator # noqa: E501
+    """
+    with app.app_context():
+        stripe.api_key = get_stripe_secret_key()
+        connect_account = get_stripe_connect_account()
+        if stripe.api_key is None:
+            log.error("Stripe api key not set refusing to update subscription statuses")
+        if connect_account is None:
+            log.error(
+                "Stripe connect account not set. Refusing to update subscription statuses"  # noqa: E501
             )
-            for stripeSubscription in stripeSubscriptions.auto_paging_iter():
-                log.debug(
-                    f"processing subscription status for Stripe subscription: {stripeSubscription.id}"  # noqa: E501
+        if stripe_connect_active():
+            try:
+                # See https://stripe.com/docs/api/subscriptions/list#list_subscriptions-status # noqa: E501
+                stripeSubscriptions = stripe.Subscription.list(
+                    stripe_account=connect_account.id, status="all", limit=100
                 )
-
-                subscription = (
-                    database.session.query(Subscription)
-                    .where(Subscription.stripe_subscription_id == stripeSubscription.id)
-                    .first()
-                )
-                if subscription:
+                for stripeSubscription in stripeSubscriptions.auto_paging_iter():
                     log.debug(
-                        f"setting Subscribie subscription {subscription.uuid} status to: {stripeSubscription.status} for Stripe subscription: {stripeSubscription.id}"  # noqa: E501
+                        f"processing subscription status for Stripe subscription: {stripeSubscription.id}"  # noqa: E501
                     )
 
-                    subscription.stripe_status = stripeSubscription.status
-                    log.info(subscription.stripe_status)
-                    log.info(subscription.stripe_subscription_id)
-                    database.session.commit()
-                else:
-                    log.warning(
-                        "subscription is in stripe but not in the subscribie database"
+                    subscription = (
+                        database.session.query(Subscription)
+                        .where(
+                            Subscription.stripe_subscription_id == stripeSubscription.id
+                        )
+                        .first()
                     )
-        except Exception as e:
-            log.warning(f"Could not update stripe subscription status: {e}")
-    else:
-        log.warning(
-            "Refusing to update subscription status since Stripe connect is not active"
-        )
+                    if subscription:
+                        log.debug(
+                            f"setting Subscribie subscription {subscription.uuid} status to: {stripeSubscription.status} for Stripe subscription: {stripeSubscription.id}"  # noqa: E501
+                        )
+
+                        subscription.stripe_status = stripeSubscription.status
+                        log.info(subscription.stripe_status)
+                        log.info(subscription.stripe_subscription_id)
+                        database.session.commit()
+                    else:
+                        log.warning(
+                            "subscription is in stripe but not in the subscribie database"  # noqa: E501
+                        )
+            except Exception as e:
+                log.warning(f"Could not update stripe subscription status: {e}")
+        else:
+            log.warning(
+                "Refusing to update subscription status since Stripe connect is not active"  # noqa: E501
+            )

--- a/subscribie/tasks.py
+++ b/subscribie/tasks.py
@@ -1,6 +1,7 @@
 import logging
 import queue
 import threading
+from flask import current_app
 
 log = logging.getLogger(__name__)
 
@@ -34,3 +35,13 @@ def fifo_queue():
 
 thread = threading.Thread(target=fifo_queue)
 thread.start()
+
+
+def background_task(f):
+    def bg_f(*a, **kw):
+        app = current_app._get_current_object()
+        kw["app"] = app  # inject flask app for app context
+
+        threading.Thread(target=f, args=a, kwargs=kw).start()
+
+    return bg_f


### PR DESCRIPTION
make update_stripe_suscription_statuses non blocking

Introduced `@background_task` [decorator](https://github.com/Subscribie/subscribie/pull/846/files#diff-8c0273704e101e10dcbac3c552c40ec822155fcb33685b141b7a614106a78fe5R40-R47)
which **always*** injects the current flask app as a keyword arg to the background task

*this may not be preferable as it forces all client code to accept an `app` or have `**kwargs` in their function definition. 

Example usage:

Defining a background task
```
@background_task
def update_stripe_subscription_statuses(app):
    # do something long running..
```

Calling: This will run in a background thread until termination:
```
update_stripe_subscription_statuses() 
```

note that passing `app` is not required since it's injected by the decorator `background_task`, but the functions definition must include `app` (or use `**kwargs`)

ref #845 