### PR TITLE
Fix #1141 include archived plans when listing agreed to documents 

### DIFF
--- a/subscribie/blueprints/admin/__init__.py
+++ b/subscribie/blueprints/admin/__init__.py
@@ -767,9 +767,11 @@ def list_documents():
         and request.args["filter"] == "terms-and-conditions-agreed"
     ):
         show_only_agreed_documents = True
-        documents = Document.query.where(
-            Document.type == "terms-and-conditions-agreed"
-        ).all()
+        documents = (
+            Document.query.where(Document.type == "terms-and-conditions-agreed")
+            .execution_options(include_archived=True)
+            .all()
+        )
     else:
         documents = Document.query.where(
             Document.type != "terms-and-conditions-agreed"


### PR DESCRIPTION
on `admin/list-documents?filter=terms-and-conditions-agreed`

Ref #1141 

Before  (after editing plan):
https://user-images.githubusercontent.com/1718624/238346075-6410d9ec-5c1d-4c7f-881b-3fb6ec69bbf5.png


After: (after editing plan(s):

![image](https://github.com/Subscribie/subscribie/assets/1718624/ddd2eb5a-a6df-4cff-beba-ee66c15492be)



