### PR TITLE
Fix #1295 As a shop owner, I can see a list of recently cancelled subscriptions via the dashboard

### DIFF
--- a/subscribie/blueprints/admin/__init__.py
+++ b/subscribie/blueprints/admin/__init__.py
@@ -1313,6 +1313,15 @@ def show_recent_subscription_cancellations():
         limit=100,
         types=["customer.subscription.deleted"],
     )
+    for event in subscription_cancellations.auto_paging_iter():
+        log.info("appending event")
+        log.info(
+            f"Length of subscription_cancellations.data is {len(subscription_cancellations.data)}"  # noqa: E501
+        )
+        if len(subscription_cancellations.data) > 100:
+            break
+        subscription_cancellations.data.append(event)
+
     cancellations = []
     # subscription id
     for index, value in enumerate(subscription_cancellations):

--- a/subscribie/blueprints/admin/stats.py
+++ b/subscribie/blueprints/admin/stats.py
@@ -1,6 +1,8 @@
 from subscribie.database import database
 from subscribie.models import Person, Subscription, Plan, PlanRequirements, Transaction
+from subscribie.utils import get_stripe_secret_key, get_stripe_connect_account_id
 from sqlalchemy.sql import func
+import stripe
 import logging
 
 
@@ -95,3 +97,16 @@ def get_number_of_transactions_with_donations():
         .count()
     )
     return count
+
+
+def get_number_of_recent_subscription_cancellations():
+    stripe.api_key = get_stripe_secret_key()
+    connect_account_id = get_stripe_connect_account_id()
+
+    subscription_cancellations = stripe.Event.list(
+        stripe_account=connect_account_id,
+        limit=100,
+        types=["customer.subscription.deleted"],
+    )
+
+    return len(subscription_cancellations)

--- a/subscribie/blueprints/admin/templates/admin/dashboard.html
+++ b/subscribie/blueprints/admin/templates/admin/dashboard.html
@@ -35,6 +35,7 @@
   <div class="card px-3 py-3 my-3">
     <h3 class="card-title justify-content-between d-flex">Stats</h3>
     <p>You have: {{ num_active_subscribers }} <a href="{{ url_for('admin.subscribers', action='show_active')}}">subscribers</a> with <em>active</em> subscriptions.</p>
+    <p>You've had: {{ num_recent_subscription_cancellations }} <a href="{{ url_for('admin.show_recent_subscription_cancellations')}}">subscription cancellations</a> in the last 30 days.</p>
     <p>You've had: {{ num_subscribers }} <a href="{{ url_for('admin.subscribers') }}">subscribers</a> since starting your shop.</p>
     <p>You've had: {{ num_one_off_purchases }} <a href="{{ url_for('admin.subscribers', action='show_one_off_payments')}}">people</a> buy a one-off item from your shop.</p>
     <p>You've had: {{ num_signups }} <a href="{{ url_for('admin.subscribers') }}">people</a> either buy one-off or start a subscription{% if settings.donations_enabled %} or donations {% endif %} since starting your shop.</p>

--- a/subscribie/blueprints/admin/templates/admin/recent_subscription_cancellations.html
+++ b/subscribie/blueprints/admin/templates/admin/recent_subscription_cancellations.html
@@ -1,0 +1,87 @@
+{% extends "admin/layout.html" %}
+{% block title %} Recent Subscription Cancellations{% endblock %}
+
+{% block body %}
+
+<h2 class="text-center text-dark mb-3">Recent Subscription Cancellations</h2>
+
+<div class="container">
+  <ul class="breadcrumb">
+    <li class="breadcrumb-item"><a href="/">Shop</a></li>
+    <li class="breadcrumb-item"><a href="{{ url_for('admin.dashboard') }}">Manage My Shop</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Recent Subscription Cancellations</li>
+  </ul>
+</div>
+<main>
+  <div class="section">
+    <div class="container">
+
+      <p>
+        Below is the list of recent subscription cancellations (if any) within the last 30 days.
+      </p>
+      <p>
+        Be sure to click the subscriber name to investigate further, since they may have since signed-up to a new, or different plan.
+      </p>
+
+      <h3>Reason Code</h3>
+      <ul style="list-style: disc">
+        <li><em>payment_failed</em> - means all retry attempts have failed and the subscription is cancelled</li>
+        <li><em>payment_disputed</em> - means the subscriber disputed the charge(s) at their bank or card issuer</li>
+        <li><em>cancellation_requested</em> - means a cancellation was requested which caused the subscription to be cancelled. If plans have a "Cancel at" date set, they will natually cancel at the "Cancel at" date set on the plan</li>
+      </ul>
+
+      <p class="alert alert-warning" role="alert">Please note this list only goes back 30 days</p>
+
+      <table class="table mobile-optimised">
+        <thead>
+          <tr>
+            <th>Subscriber</th>
+            <th>Subscription</th>
+            <th>Cancellation Date</th>
+            <th>Reason</th>
+          </tr>
+        </thead>
+        <tbody>
+        {% for cancellation in cancellations %}
+          <tr>
+            <td data-th="Name">
+              <a href="{{ url_for('admin.show_subscriber', subscriber_id=cancellation['person'].id) }}">{{ cancellation['person'].given_name }} {{ cancellation['person'].family_name }}</a>
+              <br />
+            </td>
+            <td data-th="Plan">
+              {{ cancellation['subscription'].plan.title }}
+            </td>
+            <td>
+              {{ cancellation['cancellation_date'] | timestampToDate }}
+            </td>
+            <td>
+              {{ cancellation['cancellation_reason'] }}
+            </td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div> <!-- end .container -->
+  </div><!-- end .section -->
+</main>
+
+<script>
+{# give UI feedback whilst waiting for active subscribers to load #}
+document.getElementById('show-active-subscribers').addEventListener('click', function(e) {
+  e.target.textContent = "Please wait...";
+});
+
+{# Refresh subscription statuses when button clicked #}
+btnRefreshSubscriptions = document.getElementById('refresh_subscriptions');
+
+btnRefreshSubscriptions.addEventListener('click', refreshSubscriptionStatuses);
+
+function refreshSubscriptionStatuses() {
+  fetch("{{ url_for('admin.refresh_subscriptions') }}")
+  .then(response => { document.location = "{{ url_for('admin.refresh_subscriptions') }}" });
+}
+{# End Refresh subscription statuses when button clicked #}
+
+</script>
+
+{% endblock body %}

--- a/subscribie/blueprints/admin/templates/admin/recent_subscription_cancellations.html
+++ b/subscribie/blueprints/admin/templates/admin/recent_subscription_cancellations.html
@@ -65,23 +65,4 @@
   </div><!-- end .section -->
 </main>
 
-<script>
-{# give UI feedback whilst waiting for active subscribers to load #}
-document.getElementById('show-active-subscribers').addEventListener('click', function(e) {
-  e.target.textContent = "Please wait...";
-});
-
-{# Refresh subscription statuses when button clicked #}
-btnRefreshSubscriptions = document.getElementById('refresh_subscriptions');
-
-btnRefreshSubscriptions.addEventListener('click', refreshSubscriptionStatuses);
-
-function refreshSubscriptionStatuses() {
-  fetch("{{ url_for('admin.refresh_subscriptions') }}")
-  .then(response => { document.location = "{{ url_for('admin.refresh_subscriptions') }}" });
-}
-{# End Refresh subscription statuses when button clicked #}
-
-</script>
-
 {% endblock body %}

--- a/subscribie/blueprints/admin/templates/admin/recent_subscription_cancellations.html
+++ b/subscribie/blueprints/admin/templates/admin/recent_subscription_cancellations.html
@@ -22,6 +22,13 @@
       <p>
         Be sure to click the subscriber name to investigate further, since they may have since signed-up to a new, or different plan.
       </p>
+      <h3>Total Collected &amp; Monies Owed</h3>
+      <p><em>"Total Collected"</em> is the total collected from that Subscriber <em>all time</em> accross <em>all</em> their subscriptions.</p>
+      <p><em>"Monies owed"</em> is the amount not collected, for instance due to insufficient funds accross <em>all</em> the Subscriber's account.
+      <br />To investigate further, click a Subscribers name.</p>
+
+      <p>Please note: 'Monies owed' is a guide: Subscribie isn't aware of payments if they are made outside of this system (such as cash).</p>
+
 
       <h3>Reason Code</h3>
       <ul style="list-style: disc">
@@ -39,6 +46,8 @@
             <th>Subscription</th>
             <th>Cancellation Date</th>
             <th>Reason</th>
+            <th>Total Collected</th>
+            <th>Monies Owed</th>
           </tr>
         </thead>
         <tbody>
@@ -56,6 +65,12 @@
             </td>
             <td>
               {{ cancellation['cancellation_reason'] }}
+            </td>
+            <td>
+              {{ currencyFormat(get_geo_currency_code(), cancellation['person'].balance(skipFetchDeclineCode=True)['total_collected']) }}
+            </td>
+            <td>
+              {{ currencyFormat(get_geo_currency_code(), cancellation['person'].balance(skipFetchDeclineCode=True)['customer_balance']) }}
             </td>
           </tr>
         {% endfor %}


### PR DESCRIPTION
Issue ref: #1295

# Screenshot before:

![image](https://github.com/Subscribie/subscribie/assets/1718624/7cb21f27-7b42-4495-a6ad-b1a298537488)


# Screenshot after:
![image](https://github.com/Subscribie/subscribie/assets/1718624/dcd22426-4ebe-4eb4-b344-ec3afbc3e848)

and new route `/admin/recent-subscription-cancellations`
![image](https://github.com/Subscribie/subscribie/assets/1718624/fa2dc98b-c152-4cae-aa22-8e1e5ebb3963)


How to run test(s) for this pr (see [testing]([url](https://docs.subscribie.co.uk/docs/architecture/testing/)https://docs.subscribie.co.uk/docs/architecture/testing/)):
