### PR TITLE
Fix #1301 use of colour to differentiate subscription statuses on subscriber list page

### DIFF
--- a/subscribie/blueprints/admin/templates/admin/subscribers.html
+++ b/subscribie/blueprints/admin/templates/admin/subscribers.html
@@ -108,7 +108,7 @@
                                     </li>
                                 {% endif %}
                                 <li><strong>Subscription ID: </strong>{{ subscription.uuid }}</li>
-                                <li><strong>Date started: </strong>{{ subscription.created_at.strftime('%Y-%m-%d') }}</li>
+                                <li><strong>Date started: </strong>{{ subscription.created_at.strftime('%d-%m-%Y') }}</li>
                                 <li>
                                     {% if subscription.plan.requirements and subscription.plan.requirements.subscription %}
                                         <strong>Price: </strong>
@@ -128,12 +128,18 @@
                                     <li><strong>Status:</strong>
                                         {% if subscription.plan.requirements and subscription.plan.requirements.subscription %}
                                            {% if subscription.stripe_pause_collection == "void" %}
-                                              <span class="subscription-status">Paused</span>
+                                              <div class="subscription-status alert alert-warning">Paused</div>
+                                           {% elif subscription.stripe_status == "canceled" %}
+                                              <div class="subscription-status alert alert-secondary">Canceled</div>
+                                           {% elif subscription.stripe_status == 'active'  %}
+                                              <div class="subscription-status alert alert-success">Active</div>
+                                           {% elif subscription.stripe_status == 'past_due'  %}
+                                              <div class="subscription-status alert alert-danger">past_due</div>
                                            {% else %}
-                                              <span class="subscription-status">{{ subscription.stripe_status }}</span>
+                                              <div class="subscription-status alert alert-dark">{{ subscription.stripe_status }}</div>
                                            {% endif %}
                                         {% else %}
-                                           <span class="subscription-status">Paid</span>
+                                           <div class="subscription-status alert alert-success">Paid</div>
                                         {% endif %}
                                     </li>
                                     {% if subscription.stripe_status == 'canceled' %}


### PR DESCRIPTION
Issue ref: #1301

Screenshot before:

![image](https://github.com/Subscribie/subscribie/assets/1718624/01155f7a-a88d-481c-8f65-964abf41b417)


Screenshot after:
![image](https://github.com/Subscribie/subscribie/assets/1718624/1668c132-6834-4a05-840c-bc22fec5d38c)
