### PR TITLE
Fix 1324 check subscription.note is not None before adding to subscription cancellation email

### DIFF
--- a/subscribie/blueprints/checkout/__init__.py
+++ b/subscribie/blueprints/checkout/__init__.py
@@ -912,7 +912,7 @@ def stripe_webhook():
             emailBody += "\n\nThe plan title was:\n" f"{plan.title}"
 
         if subscription is not None:
-            if subscription.note.note is not None and subscription.note.note != "":
+            if subscription.note is not None and subscription.note.note != "":
                 emailBody += (
                     "When the subscriber originally signed-up, "
                     "they provided the following note:\n\n"


### PR DESCRIPTION
Issue ref: #1324

Screenshot before:


Screenshot after:


How to run test(s) for this PR see: [Testing](https://docs.subscribie.co.uk/docs/architecture/testing/)
