### PR TITLE
Fix #1366 announce-stripe-connect error handle endpoint downtime gracefully

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Run tests
         run: |
@@ -49,7 +49,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Build image
         run: docker build . --file Dockerfile --tag $IMAGE_NAME

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,9 +21,9 @@ jobs:
         python-version: [3.12]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/subscribie/models.py
+++ b/subscribie/models.py
@@ -1198,9 +1198,7 @@ class Question(database.Model):
         database.DateTime, default=datetime.datetime.now(datetime.UTC)
     )
     options = relationship("QuestionOption", back_populates="question")
-    is_longform_question = database.Column(
-        database.Boolean(), default=False
-    )
+    is_longform_question = database.Column(database.Boolean(), default=False)
     title = database.Column(database.String())
 
 


### PR DESCRIPTION
Issue ref: #1366

Screenshot before:


Screenshot after:


How to run test(s) for this PR see: [Testing](https://docs.subscribie.co.uk/docs/architecture/testing/)
