### PR TITLE
Fix #1374 clear session chosen_question_ids_answers between plan signups

### DIFF
--- a/subscribie/blueprints/checkout/__init__.py
+++ b/subscribie/blueprints/checkout/__init__.py
@@ -762,6 +762,9 @@ def create_subscription(
                         log.error("Could not set cancel_at: {e}")
 
         newSubscriberEmailNotification()
+    # Clear chosen_question_ids_answers from session since we've now stored them
+    # Ref https://github.com/Subscribie/subscribie/issues/1374
+    session.pop("chosen_question_ids_answers", None)
     return subscription
 
 


### PR DESCRIPTION
Issue ref: #1374

Screenshot before:


Screenshot after:


How to run test(s) for this PR see: [Testing](https://docs.subscribie.co.uk/docs/architecture/testing/)
