### PR TITLE
Fix #1379 as a shop owner I see the subscriber name and email in new subscriber email notifications

### DIFF
--- a/subscribie/email.py
+++ b/subscribie/email.py
@@ -86,7 +86,7 @@ def send_welcome_email(to_email=None, subscription=None, **kwargs):
         plan=plan,
         subscriber_email=to_email,
     )
-
+    log.info(f"send_welcome_email rendered as:\n{html}")
     send_email(
         to_email=to_email,
         subject=company.name + " " + "Subscription Confirmation",

--- a/subscribie/email.py
+++ b/subscribie/email.py
@@ -5,7 +5,6 @@ from subscribie.models import (
     Setting,
     User,
     Company,
-    Plan,
     EmailTemplate,
 )
 from subscribie import settings
@@ -53,9 +52,12 @@ def send_email(to_email=None, subject=None, body_html=None, body_plaintext=None)
         log.error(f"Failed to send email. {e}")
 
 
-def send_welcome_email(to_email=None):
+def send_welcome_email(to_email=None, subscription=None, **kwargs):
     company = Company.query.first()
-    plan = Plan.query.filter_by(uuid=session.get("plan", None)).first()
+    if subscription is None:
+        log.error("Cannot send_welcome_email because subscription is None")
+        return
+    plan = subscription.plan
 
     # Send welcome email (either default template of custom, if active)
     custom_template = EmailTemplate.query.first()

--- a/subscribie/emails/user-new-subscriber-notification.jinja2.html
+++ b/subscribie/emails/user-new-subscriber-notification.jinja2.html
@@ -1,0 +1,9 @@
+You have a new subscriber! <br />
+
+{% if subscriber_email %}
+Email: {{ subscriber_email }}<br />
+{% endif %}
+
+{% if subscription %}
+Name: {{ subscription.person.given_name }} {{ subscription.person.family_name }}<br />
+{% endif %}

--- a/subscribie/signals.py
+++ b/subscribie/signals.py
@@ -46,7 +46,6 @@ def register_signal_handlers():
     """Connect signals to recievers
     This is called during flask app startup in views.py
     """
-    signal_journey_complete.connect(newSubscriberEmailNotification)
     signal_new_subscriber.connect(receiver_new_subscriber)
     signal_journey_complete.connect(receiver_attach_documents_to_subscription)
     signal_payment_failed.connect(

--- a/subscribie/views.py
+++ b/subscribie/views.py
@@ -29,7 +29,8 @@ from .models import (
 )
 from subscribie.blueprints.style import inject_custom_style
 from subscribie.database import database
-from subscribie.signals import register_signal_handlers
+from subscribie.signals import register_signal_handlers, signal_new_subscriber
+
 from subscribie.blueprints.admin.stats import (
     get_number_of_active_subscribers,
     get_monthly_revenue,
@@ -48,6 +49,7 @@ from urllib.parse import urlparse
 from pathlib import PurePosixPath
 from urllib.parse import unquote
 from sqlalchemy import func
+from subscribie.notifications import newSubscriberEmailNotification
 
 log = logging.getLogger(__name__)
 
@@ -175,6 +177,12 @@ def inject_template_globals():
 @bp.route("/health")
 def health():
     return "OK", 200
+
+
+@bp.route("/test-signal_new_subscriber")
+def test_email():
+    signal_new_subscriber.send(subscription_uuid="test")
+    return "Test signal_new_subscriber email generated."
 
 
 @bp.route("/notification")


### PR DESCRIPTION
Issue ref: #1379

- Fix #1379 as a shop owner I see the subscriber name and email in new subscriber email notifications
- Fix #1379 New subscriber notifications are only sent upon reaching thankyou page, not before


Screenshot before:


Screenshot after:


How to run test(s) for this PR see: [Testing](https://docs.subscribie.co.uk/docs/architecture/testing/)
