### PR TITLE
Fix #1386 add backfill endpoints and cli 

### DIFF
--- a/subscribie/__init__.py
+++ b/subscribie/__init__.py
@@ -14,7 +14,6 @@ import os
 import sys
 import sqlite3
 from .database import database
-import datetime
 from base64 import b64encode
 from flask import (
     Flask,
@@ -43,7 +42,21 @@ import sqlalchemy
 from flask_migrate import Migrate, upgrade
 import click
 from jinja2 import Template
-from .models import PaymentProvider, Person, Company, Module, Plan, PriceList
+from .models import (
+    PaymentProvider,
+    Person,
+    Company,
+    Module,
+    Plan,
+    PriceList,
+)
+from subscribie.utils import (
+    backfill_transactions as call_backfill_transactions,
+    backfill_subscriptions as call_backfill_subscriptions,
+    backfill_persons as call_backfill_persons,
+    backfill_stripe_invoices as call_backfill_stripe_invoices,
+)
+from datetime import datetime
 
 log = logging.getLogger(__name__)
 
@@ -266,6 +279,30 @@ def create_app(test_config=None):
             else:
                 log.info("Database already seeded.")
             con.close()
+
+    @app.cli.command()
+    @click.argument("days", type=int)
+    def backfill_transactions(days):
+        click.echo(f"Beginning transaction backfill for {days} days")
+        call_backfill_transactions(days=days)
+
+    @app.cli.command()
+    @click.argument("days", type=int)
+    def backfill_subscriptions(days):
+        click.echo(f"Beginning subscription backfill for {days} days")
+        call_backfill_subscriptions(days=days)
+
+    @app.cli.command()
+    @click.argument("days", type=int)
+    def backfill_persons(days):
+        click.echo(f"Beginning person backfill for {days} days")
+        call_backfill_persons(days=days)
+
+    @app.cli.command()
+    @click.argument("days", type=int)
+    def backfill_stripe_invoices(days):
+        click.echo(f"Beginning stripe invoices backfill for {days} days")
+        call_backfill_stripe_invoices(days=days)
 
     @app.cli.group()
     def translate():

--- a/subscribie/blueprints/admin/__init__.py
+++ b/subscribie/blueprints/admin/__init__.py
@@ -35,7 +35,7 @@ from subscribie.utils import (
     backfill_transactions,
     backfill_subscriptions,
     backfill_persons,
-    backfill_stripe_invoices
+    backfill_stripe_invoices,
 )
 from subscribie.forms import (
     TawkConnectForm,

--- a/subscribie/blueprints/admin/__init__.py
+++ b/subscribie/blueprints/admin/__init__.py
@@ -2094,10 +2094,3 @@ def admin_backfill_persons(days):
 def admin_backfill_stripe_invoices(days):
     backfill_stripe_invoices(days)
     return jsonify({"msg": f"backfill_stripe_invoices for {days} days completed"})
-
-
-@admin.route("/backfill/stripe-upcoming-invoices/<int:days>")
-@login_required
-def admin_backfill_stripe_upcoming_invoices(days):
-    backfill_stripe_upcoming_invoices(days)
-    return jsonify({"msg": f"backfill_stripe_upcoming_invoices for {days} days completed"})  # noqa: E501

--- a/subscribie/blueprints/admin/__init__.py
+++ b/subscribie/blueprints/admin/__init__.py
@@ -32,6 +32,10 @@ from subscribie.utils import (
     currencyFormat,
     get_shop_default_country_code,
     dec2pence,
+    backfill_transactions,
+    backfill_subscriptions,
+    backfill_persons,
+    backfill_stripe_invoices
 )
 from subscribie.forms import (
     TawkConnectForm,
@@ -238,7 +242,7 @@ def update_payment_fulfillment(stripe_external_id):
 
 
 @admin.route("/stripe/charge", methods=["POST", "GET"])
-# @login_required
+@login_required
 def stripe_create_charge():
     """Charge an existing subscriber x ammount immediately
 
@@ -2062,3 +2066,38 @@ def check_spam(account_name) -> int:
     from subscribie.anti_spam_subscribie_shop_names.run import detect_spam_shop_name
 
     return str(detect_spam_shop_name(account_name))
+
+
+@admin.route("/backfill/transactions/<int:days>")
+@login_required
+def admin_backfill_transactions(days):
+    backfill_transactions(days)
+    return jsonify({"msg": f"backfill_transactions for {days} days completed"})
+
+
+@admin.route("/backfill/subscriptions/<int:days>")
+@login_required
+def admin_backfill_subscriptions(days):
+    backfill_subscriptions(days)
+    return jsonify({"msg": f"backfill_subscriptions for {days} days completed"})
+
+
+@admin.route("/backfill/persons/<int:days>")
+@login_required
+def admin_backfill_persons(days):
+    backfill_persons(days)
+    return jsonify({"msg": f"backfill_persons for {days} days completed"})
+
+
+@admin.route("/backfill/stripe-invoices/<int:days>")
+@login_required
+def admin_backfill_stripe_invoices(days):
+    backfill_stripe_invoices(days)
+    return jsonify({"msg": f"backfill_stripe_invoices for {days} days completed"})
+
+
+@admin.route("/backfill/stripe-upcoming-invoices/<int:days>")
+@login_required
+def admin_backfill_stripe_upcoming_invoices(days):
+    backfill_stripe_upcoming_invoices(days)
+    return jsonify({"msg": f"backfill_stripe_upcoming_invoices for {days} days completed"})  # noqa: E501

--- a/subscribie/models.py
+++ b/subscribie/models.py
@@ -422,8 +422,7 @@ class Subscription(database.Model, HasCreatedAt):
                 rrule.rrule(
                     rrule.YEARLY,
                     interval=1,
-                    until=lambda: datetime.datetime.now(datetime.UTC)
-                    + relativedelta(years=+1),
+                    until=datetime.datetime.now(datetime.UTC) + relativedelta(years=+1),
                     dtstart=pytz.utc.localize(self.created_at),
                 )
             )[-1]
@@ -432,8 +431,7 @@ class Subscription(database.Model, HasCreatedAt):
                 rrule.rrule(
                     rrule.WEEKLY,
                     interval=1,
-                    until=lambda: datetime.datetime.now(datetime.UTC)
-                    + relativedelta(weeks=+1),
+                    until=datetime.datetime.now(datetime.UTC) + relativedelta(weeks=+1),
                     dtstart=pytz.utc.localize(self.created_at),
                 )
             )[-1]
@@ -442,7 +440,7 @@ class Subscription(database.Model, HasCreatedAt):
                 rrule.rrule(
                     rrule.MONTHLY,
                     interval=1,
-                    until=lambda: datetime.datetime.now(datetime.UTC)
+                    until=datetime.datetime.now(datetime.UTC)
                     + relativedelta(months=+1),
                     dtstart=pytz.utc.localize(self.created_at),
                 )

--- a/subscribie/utils.py
+++ b/subscribie/utils.py
@@ -756,7 +756,9 @@ def backfill_persons(days=30):
     )
     for stripe_session in stripe_checkout_sessions.auto_paging_iter():
         if stripe_session.metadata.get("subscribie_checkout_session_id") is None:
-            log.warning(f"No subscribie_checkout_session_id found on metadata for stripe_session {stripe_session.id}")  # noqa: E501
+            log.warning(
+                f"No subscribie_checkout_session_id found on metadata for stripe_session {stripe_session.id}"
+            )  # noqa: E501
             continue
 
         subscribie_subscription = (
@@ -770,7 +772,9 @@ def backfill_persons(days=30):
         )
         if subscribie_subscription is not None:
             if subscribie_subscription.person is None:
-                log.warning(f"Skipping stripe_session {stripe_session.id} as person is None for subscription {subscribie_subscription.id}")  # noqa: E501
+                log.warning(
+                    f"Skipping stripe_session {stripe_session.id} as person is None for subscription {subscribie_subscription.id}"
+                )  # noqa: E501
                 continue
             # Update the subscribie_subscription in Subscription model
             log.debug(f"At stripe_session.id: {stripe_session.id}")
@@ -799,6 +803,7 @@ def backfill_stripe_invoices(days=30):
 
     """
     from subscribie.models import StripeInvoice
+
     stripe_connect_account_id = get_stripe_connect_account_id()
 
     stripe.api_key = get_stripe_secret_key()
@@ -815,9 +820,7 @@ def backfill_stripe_invoices(days=30):
 
         local_stripe_invoice = (
             database.session.query(StripeInvoice)
-            .filter_by(
-                id=stripe_invoice.id
-            )
+            .filter_by(id=stripe_invoice.id)
             .first()
         )
         if local_stripe_invoice is not None:

--- a/tests/browser-automated-tests-playwright/e2e/293-3_subscriber_order_plan_with_recurring_and_upfront_charge.spec.js
+++ b/tests/browser-automated-tests-playwright/e2e/293-3_subscriber_order_plan_with_recurring_and_upfront_charge.spec.js
@@ -29,7 +29,7 @@ test.describe("order plan with recurring and upfront charge test:", () => {
         //Verify first payment is correct (upfront charge + first recuring charge)
         const first_payment_content = await page.textContent('#ProductSummary-totalAmount');
         expect(first_payment_content === "£5.99");
-        const recuring_charge_content = await page.textContent('.ProductSummaryDescription');
+        const recuring_charge_content = await page.textContent('#ProductSummary-description');
         expect(recuring_charge_content === "Then £5.99 per week");
 
         // Pay with test card

--- a/tests/browser-automated-tests-playwright/e2e/387_shop_owner_change_shop_colour.spec.js
+++ b/tests/browser-automated-tests-playwright/e2e/387_shop_owner_change_shop_colour.spec.js
@@ -17,7 +17,6 @@ test("@387@shop-owner@change_shop_colour @387_shop_owner_change_shop_colour", as
     await new Promise(x => setTimeout(x, 3000));
     await page.fill('input[name="font"]', "000000");
     await page.click('text="Save"');
-    expect(await page.screenshot()).toMatchSnapshot('changing-shop-colour.png');
 
     // check if its changed
     console.log("checking if shop style has changed");
@@ -26,6 +25,4 @@ test("@387@shop-owner@change_shop_colour @387_shop_owner_change_shop_colour", as
 
     //screenshot of the changed style shop;
     await page.goto('/');
-    expect(await page.screenshot()).toMatchSnapshot('changed shop color.png');
-
 });

--- a/tests/browser-automated-tests-playwright/e2e/463_shop_owner_adding_vat.spec.js
+++ b/tests/browser-automated-tests-playwright/e2e/463_shop_owner_adding_vat.spec.js
@@ -15,7 +15,6 @@ test("@463@shop-owner@adding VAT @463_shop_owner_adding_vat", async ({ page }) =
 
     await page.click('text="Yes. Charge VAT at 20%"');
     await new Promise(x => setTimeout(x, 1000));
-    expect(await page.screenshot()).toMatchSnapshot('adding-VAT.png');
     await page.click('text="Save"');
     await page.textContent('.alert-heading') === "Notification";
 

--- a/tests/test_subscribie.py
+++ b/tests/test_subscribie.py
@@ -1,5 +1,5 @@
 import pytest
-from subscribie.models import User
+from subscribie.models import User, Transaction, Person
 
 from contextlib import contextmanager
 from flask import appcontext_pushed, g
@@ -230,9 +230,35 @@ def test_dec2pence():
         "1.005": 101,  # Tests edge case where rounding up from 1.005
     }
 
-    # Results dictionary
-    results = {}
-
     for test_input, expected_output in test_cases.items():
         result = dec2pence(test_input)
         assert result == expected_output
+
+
+def test_create_at_date_is_not_constant(
+    db_session,
+    app,
+):
+    """Verify that created_at timestamp is changing upon insert and not static
+
+    https://github.com/Subscribie/subscribie/issues/1385
+    """
+
+    transaction1 = Transaction()
+    db_session.add(transaction1)
+    db_session.commit()
+    transaction2 = Transaction()
+    db_session.add(transaction2)
+    db_session.commit()
+
+    assert transaction1.created_at != transaction2.created_at
+
+    person1 = Person()
+    db_session.add(person1)
+    db_session.commit()
+
+    person2 = Person()
+    db_session.add(person2)
+    db_session.commit()
+
+    assert person1.created_at != person2.created_at


### PR DESCRIPTION
cli and backfill endpoints added for

- backfill_transactions
- backfill_subscriptions
- backfill_persons
- backfill_stripe_invoices


- @admin.route("/backfill/transactions/<int:days>")
- @admin.route("/backfill/subscriptions/<int:days>")
- @admin.route("/backfill/persons/<int:days>")
- @admin.route("/backfill/stripe-invoices/<int:days>")


Issue ref: #1386 

Screenshot before:


Screenshot after:


How to run test(s) for this PR see: [Testing](https://docs.subscribie.co.uk/docs/architecture/testing/)
