### PR TITLE
Fix #1413 ensure plans always have default pricelists attached (regression)

### DIFF
--- a/subscribie/models.py
+++ b/subscribie/models.py
@@ -721,8 +721,15 @@ class Plan(database.Model, HasArchived, HasCreatedAt):
         log.debug(
             f"Searching for price_list in currency {currency} for plan {self.title}"  # noqa: E501
         )
-
         price_list_found_for_currency = False
+
+        # Ensure plan has at least default price lists attached
+        # https://github.com/Subscribie/subscribie/issues/1413
+        if len(self.price_lists) == 0:
+            log.debug("plan price_lists is zero. Calling assignDefaultPriceLists")
+            self.assignDefaultPriceLists()
+            database.session.commit()
+
         for price_list in self.price_lists:
             log.debug(f"only use price list if currency {currency}")
 


### PR DESCRIPTION
Issue ref: #1413

Fix #1413 ensure plans always have default pricelists attached (regression*)

*Previously all plans were ensured to have default price_lists attached at app start up, causing significantly slow app start-up times (due to sites with 100s of plan revisions (since plans are immutable, each edit creates a new plan id). The app-startup logic to ensure all plans had price_lists was removed (causing the regression). Resolved by ensuring plans have at least default price lists on-access (a  crude `len(self.price_lists) > 0` check)

Screenshot before:


Screenshot after:


How to run test(s) for this PR see: [Testing](https://docs.subscribie.co.uk/docs/architecture/testing/)

TODO: app startup time test?
