### PR TITLE
Fix #1417 As a shop owner I'm warned when I've not configured the rely-to (support) email address

### DIFF
--- a/subscribie/blueprints/admin/__init__.py
+++ b/subscribie/blueprints/admin/__init__.py
@@ -1351,7 +1351,14 @@ def add_custom_code():
 
 @admin.app_context_processor
 def inject_template_globals():
-    return dict(currencyFormat=currencyFormat)
+    reply_to_email_address = None
+    setting = Setting.query.first()
+    if setting is not None:
+        reply_to_email_address = setting.reply_to_email_address
+    return dict(
+        currencyFormat=currencyFormat,
+        reply_to_email_address=reply_to_email_address,  # noqa: E501
+    )
 
 
 @admin.route("/subscribers")

--- a/subscribie/blueprints/admin/templates/admin/dashboard.html
+++ b/subscribie/blueprints/admin/templates/admin/dashboard.html
@@ -29,6 +29,11 @@
           </a>
           </li>
           {% endif %}
+          {% if reply_to_email_address is sameas None %}
+          <li>
+            🔔 Improve support for your subscribers by <a href="{{ url_for('admin.set_reply_to_email') }}">setting your support email address 🔔</a>
+          </li>
+          {% endif %}
       </ul>
   </div>
 


### PR DESCRIPTION
Issue ref: #1417

Screenshot before:


Screenshot after:
![image](https://github.com/user-attachments/assets/2d6c7810-5edf-4b78-b170-bf5b5e27554e)


How to run test(s) for this PR see: [Testing](https://docs.subscribie.co.uk/docs/architecture/testing/)
