### PR TITLE
1457 as a shop owner when i pause an individual subscription its new state is reflected instantly

### DIFF
--- a/subscribie/blueprints/admin/templates/admin/subscriber/show_subscriber.html
+++ b/subscribie/blueprints/admin/templates/admin/subscriber/show_subscriber.html
@@ -208,7 +208,23 @@
             {% for subscription in person.subscriptions %}
               <li class="list-group-item">
                 <strong>{{ subscription.plan.title }}</strong><br />
-                <strong>Subscription Status:</strong> {{ subscription.stripe_status or 'Unknown' }} {% if subscription.transactions|length > 0 %}<a href="{{ url_for('admin.refresh_subscription', subscription_uuid=subscription.uuid, person_id=person.id) }}">(Refresh)</a>{% endif %}
+                <strong>Subscription Status:</strong>
+                {% if subscription.stripe_status == "resource_missing" %}
+                  Obsolete
+                  <details style="display: inline">
+                    <summary><em><small>explain</small></em></summary>
+                    <div class="alert alert-info">
+                      <p>An "Obsolete" Subscription status is when a subscription is no-longer associated
+                      with your shop (resource_missing).</p>
+                      <p>For example, when you switch your shop from 'test' mode to 'live mode',
+                      all of your 'test' subscriptions are obsolete, since they are not connected
+                      to your 'live' shop (hence they are obsolete records).</p>
+                    </div>
+                  </details>
+                {% else %}
+                  {{ subscription.stripe_status or 'Unknown' }}
+                {% endif %}
+                {% if subscription.transactions|length > 0 %}<a href="{{ url_for('admin.refresh_subscription', subscription_uuid=subscription.uuid, person_id=person.id) }}">(Refresh)</a>{% endif %}
                 <br />
                 <strong>Payment Collection Status:</strong>
                   {% if subscription.plan.requirements and subscription.plan.requirements.subscription %}

--- a/subscribie/blueprints/admin/templates/admin/subscribers.html
+++ b/subscribie/blueprints/admin/templates/admin/subscribers.html
@@ -248,12 +248,10 @@
                                         {% endif %}
                                     </li>
                                     <li><strong>Actions: </strong><br />
-                                      {# always show Force Refresh link so long as there's > 0 transactions against a subscription #}
-                                        {% if subscription.transactions|length > 0 %}
-                                              <a href="{{ url_for('admin.refresh_subscription', subscription_uuid=subscription.uuid) }}">
-                                                Refresh Status
-                                              </a> |
-                                        {% endif %}
+                                      {# always show Force Refresh link regardless if there's > 0 transactions against a subscription #}
+                                        <a href="{{ url_for('admin.refresh_subscription', subscription_uuid=subscription.uuid) }}">
+                                          Refresh Status
+                                        </a> |
                                         {% if subscription.plan.requirements and subscription.plan.requirements.subscription %}
                                             {% if subscription.stripe_status|lower in ['active', 'trialing', 'past_due', 'unpaid'] %}
                                                 {% if subscription.stripe_status|lower != 'trialing' and subscription.stripe_pause_collection != 'void' %}

--- a/subscribie/blueprints/admin/templates/admin/subscribers.html
+++ b/subscribie/blueprints/admin/templates/admin/subscribers.html
@@ -157,6 +157,19 @@
                                           <div class="subscription-status alert alert-success">Active</div>
                                         {% elif subscription.stripe_status == 'past_due'  %}
                                           <div class="subscription-status alert alert-danger">past_due</div>
+                                        {% elif subscription.stripe_status == 'resource_missing'  %}
+                                          <div class="subscription-status alert alert-dark">Obsolete
+                                            <details style="display: inline">
+                                              <summary><em><small>explain</small></em></summary>
+                                              <div class="alert alert-info">
+                                               <p>An "Obsolete" Subscription status is when a subscription is no-longer associated
+                                               with your shop (resource_missing).</p>
+                                               <p>For example, when you switch your shop from 'test' mode to 'live mode',
+                                               all of your 'test' subscriptions are obsolete, since they are not connected
+                                               to your 'live' shop (hence they are obsolete records).</p>
+                                              </div>
+                                             </details>
+                                          </div>
                                         {% else %}
                                           <div class="subscription-status alert alert-dark">{{ subscription.stripe_status }}</div>
                                         {% endif %}
@@ -221,6 +234,19 @@
                                               <div class="subscription-status alert alert-success">Active</div>
                                            {% elif subscription.stripe_status == 'past_due'  %}
                                               <div class="subscription-status alert alert-danger">past_due</div>
+                                           {% elif subscription.stripe_status == 'resource_missing' %}
+                                              <div class="subscription-status alert alert-dark">Obsolete
+                                              <details style="display: inline">
+                                                <summary><em><small>explain</small></em></summary>
+                                                <div class="alert alert-info">
+                                                <p>An "Obsolete" Subscription status is when a subscription is no-longer associated
+                                                with your shop (resource_missing).</p>
+                                                <p>For example, when you switch your shop from 'test' mode to 'live mode',
+                                                all of your 'test' subscriptions are obsolete, since they are not connected
+                                                to your 'live' shop (hence they are obsolete records).</p>
+                                                </div>
+                                              </details>
+                                              </div>
                                            {% else %}
                                               <div class="subscription-status alert alert-dark">{{ subscription.stripe_status }}</div>
                                            {% endif %}

--- a/subscribie/blueprints/checkout/__init__.py
+++ b/subscribie/blueprints/checkout/__init__.py
@@ -935,7 +935,7 @@ def stripe_webhook():
 
     stripe_livemode = PaymentProvider.query.first().stripe_livemode
     if stripe_livemode != event["livemode"]:
-        log.warn(
+        log.warning(
             f"Received a Stripe webhook event in a different livemode: {event['livemode']},  to the livemode currently set: '{stripe_livemode}'"  # noqa: E501
         )
 


### PR DESCRIPTION
Issue ref: #1457


Handles condition where stripe subscription object is `resource_missing` due to changing connect accounts (from wheb in test mode to live) for instance and/or the test account is no longer present.

Screenshot before:


Screenshot after:


How to run test(s) for this PR see: [Testing](https://docs.subscribie.co.uk/docs/architecture/testing/)
