### PR TITLE
Fix #1485 restore Show Archived button on subscribers page

### DIFF
--- a/subscribie/blueprints/admin/templates/admin/subscribers-archived.html
+++ b/subscribie/blueprints/admin/templates/admin/subscribers-archived.html
@@ -141,12 +141,5 @@
   </div><!-- end .section -->
 </main>
 
-<script>
-{# give UI feedback whilst waiting for active subscribers to load #}
-document.getElementById('show-active-subscribers').addEventListener('click', function(e) {
-  e.target.textContent = "Please wait...";
-});
-
-</script>
 
 {% endblock body %} 

--- a/subscribie/blueprints/admin/templates/admin/subscribers.html
+++ b/subscribie/blueprints/admin/templates/admin/subscribers.html
@@ -28,6 +28,7 @@
               <a href="{{url_for('admin.subscribers', action='show_donors')}}" id="show-donors" class="btn btn-primary ">Show Donors</a>
           {% endif %}
       {% endif %}
+      <a href="{{ url_for('admin.archived_subscribers') }}" id="show-archived-subscribers" class="btn btn-secondary">Show Archived</a>
       <button id="refresh_subscriptions" title="Get latest subscription statuses (active/paused/inactive)" class="btn btn-primary disable-on-click">Refresh Subscriptions</button>
        </div>
         <form action="#" method="GET">


### PR DESCRIPTION
Re-add the 'Show Archived' button to
`subscribie/blueprints/admin/templates/admin/subscribers.html` linking to the existing `admin.archived_subscribers` route, which was inadvertently removed in commit 971f7b1.

Also remove a broken `<script>` block from
`subscribie/blueprints/admin/templates/admin/subscribers-archived.html` that referenced a non-existent `#show-active-subscribers` element, causing a JS error on every page load.

Issue ref: #1485

Screenshot before:


Screenshot after:


How to run test(s) for this PR see: [Testing](https://docs.subscribie.co.uk/docs/architecture/testing/)
